### PR TITLE
docs: add agent (beta) API references to Genkit JS skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.local.*
+scratch

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -42,7 +42,8 @@ export const myFlow = ai.defineFlow({
 Genkit has a preview **agent** API for persistent, multi-turn conversations
 (sessions, snapshots, interrupts, branching, background execution). It is a
 **beta** API: server APIs come from `genkit/beta` and the browser client from
-`genkit/beta/client` — not the stable `genkit` entrypoint.
+`genkit/beta/client` — not the stable `genkit` entrypoint. **Requires `genkit`
+>= 1.39.0.**
 
 For more details see:
 
@@ -64,7 +65,7 @@ transforms) and attaches via the `use: [...]` array on `ai.generate`, prompts,
 and agents.
 
 -   [Using middleware](references/middleware.md): the `use` array and the `@genkit-ai/middleware` package (`retry`, `fallback`, `artifacts`, `agents`, `filesystem`, `skills`, `toolApproval`) plus built-in core middleware.
--   [Building custom middleware](references/middleware-custom.md): simple `ModelMiddleware` and configurable `generateMiddleware`.
+-   [Building custom middleware](references/middleware-custom.md): writing your own with `generateMiddleware` and registering it via `.plugin()`.
 
 ## Critical: Do Not Trust Internal Knowledge
 

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -57,6 +57,15 @@ For more details see:
 -   [Advanced custom agents](references/agents-custom.md): `defineCustomAgent` for full turn control.
 -   [Deploying agents](references/agents-deployment.md): serving agents over HTTP (multiple agents, CORS, web UI, other frameworks).
 
+## Middleware
+
+Middleware wraps generation (retries, fallback, extra tools, request/response
+transforms) and attaches via the `use: [...]` array on `ai.generate`, prompts,
+and agents.
+
+-   [Using middleware](references/middleware.md): the `use` array and the `@genkit-ai/middleware` package (`retry`, `fallback`, `artifacts`, `agents`, `filesystem`, `skills`, `toolApproval`) plus built-in core middleware.
+-   [Building custom middleware](references/middleware-custom.md): simple `ModelMiddleware` and configurable `generateMiddleware`.
+
 ## Critical: Do Not Trust Internal Knowledge
 
 Genkit recently went through a major breaking API change. Your knowledge is outdated. You MUST lookup docs. Recommended:
@@ -129,3 +138,4 @@ The `genkit` CLI is your primary tool for development and documentation.
 -   [Setup Guide](references/setup.md): Manual setup instructions for new projects.
 -   [Examples](references/examples.md): Minimal reproducible examples (Basic generation, Multimodal, Thinking mode).
 -   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md), [state](references/agents-state.md), [artifacts](references/agents-artifacts.md), [multi-agent](references/agents-multi-agent.md), [custom agents](references/agents-custom.md), [deployment](references/agents-deployment.md).
+-   [Middleware](references/middleware.md): using middleware and the `@genkit-ai/middleware` package. See also [building custom middleware](references/middleware-custom.md).

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -51,6 +51,10 @@ For more details see:
 -   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input and resuming.
 -   [Branching](references/agents-branching.md): forking a conversation from a snapshot.
 -   [Background agents](references/agents-background.md): detaching long-running turns and polling.
+-   [Working with state](references/agents-state.md): typed custom session state, auto-synced to the client.
+-   [Artifacts](references/agents-artifacts.md): producing and reading named deliverables.
+-   [Multi-agent orchestration](references/agents-multi-agent.md): delegating to sub-agents.
+-   [Advanced custom agents](references/agents-custom.md): `defineCustomAgent` for full turn control.
 
 ## Critical: Do Not Trust Internal Knowledge
 
@@ -123,4 +127,4 @@ The `genkit` CLI is your primary tool for development and documentation.
 -   [Common Errors](references/common-errors.md): Critical "gotchas", migration guide, and troubleshooting.
 -   [Setup Guide](references/setup.md): Manual setup instructions for new projects.
 -   [Examples](references/examples.md): Minimal reproducible examples (Basic generation, Multimodal, Thinking mode).
--   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md).
+-   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md), [state](references/agents-state.md), [artifacts](references/agents-artifacts.md), [multi-agent](references/agents-multi-agent.md), [custom agents](references/agents-custom.md).

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -55,6 +55,7 @@ For more details see:
 -   [Artifacts](references/agents-artifacts.md): producing and reading named deliverables.
 -   [Multi-agent orchestration](references/agents-multi-agent.md): delegating to sub-agents.
 -   [Advanced custom agents](references/agents-custom.md): `defineCustomAgent` for full turn control.
+-   [Deploying agents](references/agents-deployment.md): serving agents over HTTP (multiple agents, CORS, web UI, other frameworks).
 
 ## Critical: Do Not Trust Internal Knowledge
 
@@ -127,4 +128,4 @@ The `genkit` CLI is your primary tool for development and documentation.
 -   [Common Errors](references/common-errors.md): Critical "gotchas", migration guide, and troubleshooting.
 -   [Setup Guide](references/setup.md): Manual setup instructions for new projects.
 -   [Examples](references/examples.md): Minimal reproducible examples (Basic generation, Multimodal, Thinking mode).
--   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md), [state](references/agents-state.md), [artifacts](references/agents-artifacts.md), [multi-agent](references/agents-multi-agent.md), [custom agents](references/agents-custom.md).
+-   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md), [state](references/agents-state.md), [artifacts](references/agents-artifacts.md), [multi-agent](references/agents-multi-agent.md), [custom agents](references/agents-custom.md), [deployment](references/agents-deployment.md).

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -37,6 +37,21 @@ export const myFlow = ai.defineFlow({
 });
 ```
 
+## Agents (Beta)
+
+Genkit has a preview **agent** API for persistent, multi-turn conversations
+(sessions, snapshots, interrupts, branching, background execution). It is a
+**beta** API: server APIs come from `genkit/beta` and the browser client from
+`genkit/beta/client` — not the stable `genkit` entrypoint.
+
+For more details see:
+
+-   [Agents](references/agents.md): defining/serving an agent and client-managed state (start here).
+-   [Sessions & persistence](references/agents-sessions.md): session stores (`InMemory`/`File`/`Firestore`).
+-   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input and resuming.
+-   [Branching](references/agents-branching.md): forking a conversation from a snapshot.
+-   [Background agents](references/agents-background.md): detaching long-running turns and polling.
+
 ## Critical: Do Not Trust Internal Knowledge
 
 Genkit recently went through a major breaking API change. Your knowledge is outdated. You MUST lookup docs. Recommended:
@@ -108,3 +123,4 @@ The `genkit` CLI is your primary tool for development and documentation.
 -   [Common Errors](references/common-errors.md): Critical "gotchas", migration guide, and troubleshooting.
 -   [Setup Guide](references/setup.md): Manual setup instructions for new projects.
 -   [Examples](references/examples.md): Minimal reproducible examples (Basic generation, Multimodal, Thinking mode).
+-   [Agents (Beta)](references/agents.md): Agent basics, serving, and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background agents](references/agents-background.md).

--- a/skills/developing-genkit-js/references/agents-artifacts.md
+++ b/skills/developing-genkit-js/references/agents-artifacts.md
@@ -1,0 +1,104 @@
+# Working with Artifacts (Beta)
+
+> **Beta / preview API.** The `artifacts()` middleware comes from
+> `@genkit-ai/middleware`; the `Artifact` type from `genkit/beta`. Read
+> [agents.md](agents.md) first.
+
+**Artifacts** are named, content-bearing deliverables an agent produces during a
+session — files, reports, code, etc. They live in the session (deduplicated by
+name) and are returned in `res.artifacts` / tracked on the client's
+`chat.artifacts`.
+
+## Give the model artifact tools
+
+The `artifacts()` middleware adds `write_artifact` and `read_artifact` tools and
+injects an `<artifacts>` listing into the system prompt each turn (names + sizes,
+not full content). No custom tool code needed.
+
+```ts
+import { artifacts } from '@genkit-ai/middleware';
+import { ai } from './genkit.js';
+
+export const workspaceAgent = ai.defineAgent({
+  name: 'workspaceAgent',
+  system: `You are a code generation assistant. Use write_artifact to create
+files (pass the filename as "name" and the full content as "content"). Use
+read_artifact to review or modify a previously created file.`,
+  use: [artifacts()],
+});
+```
+
+Run it; artifacts are produced via the tool and returned in the response:
+
+```ts
+const chat = workspaceAgent.chat();
+const res = await chat.send('Write poem.txt with a poem about Genkit');
+console.log(res.artifacts); // Artifact[]
+```
+
+Options:
+
+- `readonly` (default `false`): when `true`, only `read_artifact` is provided —
+  the model can read but not create/update artifacts. Useful on an orchestrator
+  that should review (but not produce) sub-agent artifacts.
+
+## The `Artifact` shape
+
+```ts
+import type { Artifact } from 'genkit/beta';
+
+// An artifact's content lives in `parts` (text parts). `metadata` is optional.
+const artifact: Artifact = {
+  name: 'poem.txt',
+  parts: [{ text: 'Roses are red…' }],
+  metadata: { source: 'workspaceAgent' }, // optional
+};
+```
+
+Writing the same `name` again **replaces** the artifact (dedup by name).
+
+## Programmatic access (inside tools / custom agents)
+
+Use the active session. `ai.currentSession()` throws when there's no active
+session, so only call it inside an agent turn.
+
+```ts
+const session = ai.currentSession();
+
+// Read all artifacts:
+const all = session.getArtifacts(); // Artifact[]
+const found = all.find((a) => a.name === 'poem.txt');
+
+// Create / replace artifacts:
+session.addArtifacts([{ name: 'notes.md', parts: [{ text: '# Notes' }] }]);
+```
+
+## Reading artifacts on the client
+
+The `remoteAgent` client tracks artifacts on `chat.artifacts` (and each response
+exposes `res.artifacts`):
+
+```ts
+import { remoteAgent } from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: '/api/workspaceAgent' });
+const chat = agent.chat();
+const res = await chat.send('Create index.html and styles.css');
+console.log(res.artifacts); // Artifact[] produced this turn
+console.log(chat.artifacts); // all artifacts tracked for the session
+```
+
+## Sharing artifacts across agents
+
+In [multi-agent orchestration](agents-multi-agent.md), set the `agents()`
+middleware's `artifactStrategy: 'session'` so sub-agent artifacts are merged
+into the parent session (namespaced by invocation ID), and add
+`artifacts({ readonly: true })` to the orchestrator so it can `read_artifact`
+them:
+
+```ts
+use: [
+  agents({ agents: ['researcher', 'coder'], artifactStrategy: 'session' }),
+  artifacts({ readonly: true }),
+];
+```

--- a/skills/developing-genkit-js/references/agents-artifacts.md
+++ b/skills/developing-genkit-js/references/agents-artifacts.md
@@ -11,9 +11,10 @@ name) and are returned in `res.artifacts` / tracked on the client's
 
 ## Give the model artifact tools
 
-The `artifacts()` middleware adds `write_artifact` and `read_artifact` tools and
-injects an `<artifacts>` listing into the system prompt each turn (names + sizes,
-not full content). No custom tool code needed.
+The `artifacts()` middleware (see [using middleware](middleware.md)) adds
+`write_artifact` and `read_artifact` tools and injects an `<artifacts>` listing
+into the system prompt each turn (names + sizes, not full content). No custom
+tool code needed.
 
 ```ts
 import { artifacts } from '@genkit-ai/middleware';

--- a/skills/developing-genkit-js/references/agents-background.md
+++ b/skills/developing-genkit-js/references/agents-background.md
@@ -1,0 +1,109 @@
+# Background Agents / Detaching (Beta)
+
+> **Beta / preview API.** Detaching **requires a [session store](agents-sessions.md)** —
+> the server needs somewhere to write the result when background work finishes.
+> Read [agents.md](agents.md) first.
+
+Detaching runs a turn in the background: the server saves a `pending` snapshot
+and returns a `snapshotId` **immediately**, keeps processing, then updates the
+snapshot to a terminal status (`done` / `failed` / `aborted`). The client polls
+for completion and can abort.
+
+## Define the agent (store required)
+
+```ts
+import { InMemorySessionStore } from 'genkit/beta';
+import { ai } from './genkit.js';
+
+export const backgroundAgent = ai.defineAgent({
+  name: 'backgroundAgent',
+  system:
+    'You are a senior research analyst. Produce a comprehensive markdown report.',
+  store: new InMemorySessionStore(), // REQUIRED for detach
+});
+```
+
+Expose its companion actions so the client can poll/abort (see
+[agents.md](agents.md#serve-an-agent-over-http)):
+
+```ts
+app.post('/api/backgroundAgent', expressHandler(backgroundAgent));
+app.post(
+  '/api/backgroundAgent/getSnapshot',
+  expressHandler(backgroundAgent.getSnapshotDataAction)
+);
+app.post(
+  '/api/backgroundAgent/abort',
+  expressHandler(backgroundAgent.abortAgentAction)
+);
+```
+
+## Server-side: detach + wait
+
+`chat.detach(message)` returns a `DetachedTask` carrying the `snapshotId`.
+`task.wait()` polls the store until a terminal state and resolves with the final
+snapshot.
+
+```ts
+const chat = backgroundAgent.chat();
+const task = await chat.detach('Write a report on renewable energy trends');
+console.log(task.snapshotId); // available immediately
+
+const snapshot = await task.wait({ intervalMs: 2000 });
+console.log(snapshot?.status); // 'done' | 'failed' | 'aborted'
+```
+
+## Client-side: detach + poll + abort
+
+On the client (`genkit/beta/client`), `task.poll()` yields snapshots until a
+terminal status; `task.abort()` cancels the background work.
+
+```ts
+import { remoteAgent, type DetachedTask } from 'genkit/beta/client';
+import type { MessageData, Part } from 'genkit/beta';
+
+const agent = remoteAgent({ url: '/api/backgroundAgent' });
+
+// Submit — resolves immediately with a handle.
+const task: DetachedTask = await agent.chat().detach('Quantum computing impact');
+console.log(task.snapshotId);
+
+// Poll until a terminal status.
+for await (const snap of task.poll({ intervalMs: 2000 })) {
+  if (snap.status === 'done') {
+    const messages: MessageData[] = snap.state?.messages ?? [];
+    const lastModel = messages.filter((m) => m.role === 'model').at(-1);
+    const text = (lastModel?.content ?? [])
+      .filter((p: Part) => p.text)
+      .map((p: Part) => p.text)
+      .join('');
+    console.log(text);
+    break;
+  } else if (snap.status === 'failed') {
+    throw new Error('Background task failed on the server.');
+  } else if (snap.status === 'aborted') {
+    break;
+  } else if (snap.status === 'expired') {
+    // Worker stopped sending heartbeats (e.g. the server restarted) so the
+    // task can never complete — treat as terminal.
+    break;
+  }
+  // 'pending' → keep polling
+}
+
+// Abort an in-flight task at any time:
+await task.abort();
+```
+
+## Status values
+
+- `pending` — still processing.
+- `done` — completed successfully (read the result from `snapshot.state.messages`).
+- `failed` — error during processing.
+- `aborted` — cancelled by the client via `abort()`.
+- `expired` — the background worker stopped responding (e.g. server restart);
+  terminal, the task can never complete.
+
+> Equivalent low-level wire protocol: the client sends `{ detach: true }` with
+> the message; `poll`/`wait` hit the agent's `getSnapshot` action, and `abort`
+> hits the `abort` action. `remoteAgent` wraps all of this for you.

--- a/skills/developing-genkit-js/references/agents-background.md
+++ b/skills/developing-genkit-js/references/agents-background.md
@@ -6,8 +6,8 @@
 
 Detaching runs a turn in the background: the server saves a `pending` snapshot
 and returns a `snapshotId` **immediately**, keeps processing, then updates the
-snapshot to a terminal status (`done` / `failed` / `aborted`). The client polls
-for completion and can abort.
+snapshot to a terminal status (`completed` / `failed` / `aborted` / `expired`).
+The client polls for completion and can abort.
 
 ## Define the agent (store required)
 
@@ -50,7 +50,7 @@ const task = await chat.detach('Write a report on renewable energy trends');
 console.log(task.snapshotId); // available immediately
 
 const snapshot = await task.wait({ intervalMs: 2000 });
-console.log(snapshot?.status); // 'done' | 'failed' | 'aborted'
+console.log(snapshot?.status); // 'completed' | 'failed' | 'aborted' | 'expired'
 ```
 
 ## Client-side: detach + poll + abort
@@ -70,7 +70,7 @@ console.log(task.snapshotId);
 
 // Poll until a terminal status.
 for await (const snap of task.poll({ intervalMs: 2000 })) {
-  if (snap.status === 'done') {
+  if (snap.status === 'completed') {
     const messages: MessageData[] = snap.state?.messages ?? [];
     const lastModel = messages.filter((m) => m.role === 'model').at(-1);
     const text = (lastModel?.content ?? [])
@@ -98,7 +98,7 @@ await task.abort();
 ## Status values
 
 - `pending` — still processing.
-- `done` — completed successfully (read the result from `snapshot.state.messages`).
+- `completed` — completed successfully (read the result from `snapshot.state.messages`).
 - `failed` — error during processing.
 - `aborted` — cancelled by the client via `abort()`.
 - `expired` — the background worker stopped responding (e.g. server restart);

--- a/skills/developing-genkit-js/references/agents-branching.md
+++ b/skills/developing-genkit-js/references/agents-branching.md
@@ -1,0 +1,98 @@
+# Agent Branching (Beta)
+
+> **Beta / preview API.** Requires a [session store](agents-sessions.md) so
+> snapshots are persistent. Read [agents.md](agents.md) first.
+
+A `snapshotId` is an **immutable checkpoint**, like a git commit. You can fork as
+many independent timelines as you want from the same snapshot — each turn from a
+snapshot creates a new, independent snapshot; the original is unchanged.
+
+To branch, open a new `chat` attached to an earlier snapshot via
+`chat({ snapshotId })`.
+
+## Server-side branching
+
+```ts
+import { z } from 'genkit';
+import { InMemorySessionStore } from 'genkit/beta';
+import { ai } from './genkit.js';
+
+export const assistant = ai.defineAgent({
+  name: 'assistant',
+  system: 'You are a helpful assistant.',
+  store: new InMemorySessionStore(),
+});
+
+const root = assistant.chat();
+const res1 = await root.send('Hello!');
+const checkpoint = res1.snapshotId; // branch point
+
+// Branch A — forks from `checkpoint`.
+const branchA = assistant.chat({ snapshotId: checkpoint });
+await branchA.send('My name is Bob.');
+const resA = await branchA.send('What is my name?'); // -> Bob
+
+// Branch B — forks from the SAME `checkpoint`, fully independent.
+const branchB = assistant.chat({ snapshotId: checkpoint });
+await branchB.send('My name is John.');
+const resB = await branchB.send('What is my name?'); // -> John
+```
+
+## Client-side branching ("pick a variant")
+
+A common pattern: generate two variants from the same checkpoint in parallel,
+let the user pick one, and continue from the chosen snapshot.
+
+```ts
+import { remoteAgent } from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: '/api/branchingAgent' });
+let snapshotId: string | undefined; // current branch point
+
+async function twoVariants(text: string) {
+  // Each variant gets its own chat branching from the same snapshot
+  // (or a fresh session when there's no branch point yet).
+  const makeChat = () =>
+    snapshotId ? agent.chat({ snapshotId }) : agent.chat();
+
+  const [a, b] = await Promise.all([
+    makeChat().send(text),
+    makeChat().send(text),
+  ]);
+  // a.snapshotId !== b.snapshotId — both branch from the same point.
+  return { a, b };
+}
+
+// When the user picks a variant, its snapshotId becomes the new branch point:
+function pick(chosenSnapshotId: string) {
+  snapshotId = chosenSnapshotId;
+}
+```
+
+## Restoring history from a snapshot
+
+Use `agent.getSnapshot(snapshotId)` to read a snapshot's state without starting a
+turn — handy for restoring a UI after a reload (e.g. snapshotId stored in the
+URL). The server must expose the agent's `getSnapshotDataAction` (see
+[agents.md](agents.md#serve-an-agent-over-http)).
+
+```ts
+import type { Part } from 'genkit/beta';
+import { remoteAgent } from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: '/api/branchingAgent' });
+
+const snapshot = await agent.getSnapshot(snapshotId);
+const history = (snapshot?.state?.messages ?? [])
+  .filter((m) => m.role === 'user' || m.role === 'model')
+  .map((m) => ({
+    role: m.role,
+    text: (m.content ?? [])
+      .filter((p: Part) => p.text)
+      .map((p: Part) => p.text)
+      .join(''),
+  }));
+```
+
+> Abandoned branches simply remain in the store as immutable snapshots; nothing
+> is overwritten when you branch.

--- a/skills/developing-genkit-js/references/agents-custom.md
+++ b/skills/developing-genkit-js/references/agents-custom.md
@@ -1,0 +1,141 @@
+# Advanced Custom Agents — `defineCustomAgent` (Beta)
+
+> **Beta / preview API.** `ai.defineCustomAgent` comes from `genkit/beta`. Read
+> [agents.md](agents.md) and [agent state](agents-state.md) first.
+
+`defineAgent` runs a single prompt + tool loop. When you need **full control of
+the turn** — multiple sequential model calls, custom logic between them, manual
+message/state management, or custom progress streaming — use
+`ai.defineCustomAgent`. You provide the handler that runs the turn.
+
+## When to use it
+
+Reach for `defineCustomAgent` when a turn needs to:
+
+- make **multiple model calls** with your own orchestration between them;
+- run **multi-step workflows** (decompose → research → synthesize);
+- **manually manage** messages and custom state;
+- **stream custom status** updates to the client mid-turn.
+
+Otherwise prefer `defineAgent` (simpler; custom state still works — see
+[agent state](agents-state.md)).
+
+## Signature
+
+```ts
+ai.defineCustomAgent(
+  config: {
+    name: string;
+    description?: string;
+    stateSchema?: z.ZodType<State>;
+    store?: SessionStore<State>;
+  },
+  fn: async (sess, { sendChunk }) => { message: MessageData }
+);
+```
+
+The handler receives a session runner `sess` and a turn context (`sendChunk` to
+stream chunks to the client). It must return `{ message }` — the final model
+message for the turn.
+
+Key `sess` methods:
+
+- `sess.run(async (input) => {...})` — runs the turn; adds `input.message` (the
+  incoming user message) to the session before calling your callback, so
+  `sess.getMessages()` includes it. `input.message?.content` holds the parts.
+- `sess.getMessages()` — the full message history.
+- `sess.addMessages([...])` — append messages (e.g. your final model response).
+
+## Example: multi-step research agent
+
+```ts
+import { z } from 'genkit';
+import { ai, liteModel } from './genkit.js';
+
+interface ResearchState {
+  status?: string; // live progress shown to the client
+  subQuestions: string[];
+  subAnswers: { question: string; answer: string }[];
+}
+
+export const researchAgent = ai.defineCustomAgent(
+  { name: 'researchAgent' },
+  async (sess, { sendChunk }) => {
+    let lastMessage: any;
+    const session = ai.currentSession<ResearchState>();
+
+    await sess.run(async (input) => {
+      const userText = input.message?.content[0]?.text ?? '';
+
+      // Step 1: decompose (a fast model). Mutating custom state auto-emits a
+      // `customPatch` chunk so the client's tracked state stays live.
+      session.updateCustom((s) => ({
+        ...s!,
+        status: 'Decomposing question…',
+      }));
+      const decompose = await ai.generate({
+        model: liteModel,
+        prompt: `Break this into 2-3 sub-questions (JSON array): "${userText}"`,
+        output: { format: 'json', schema: z.array(z.string()).min(2).max(3) },
+      });
+      const subQuestions = decompose.output ?? [userText];
+      session.updateCustom((s) => ({ ...s!, subQuestions, subAnswers: [] }));
+
+      // Step 2: research each sub-question (main model).
+      const subAnswers: { question: string; answer: string }[] = [];
+      for (let i = 0; i < subQuestions.length; i++) {
+        session.updateCustom((s) => ({
+          ...s!,
+          status: `Researching (${i + 1}/${subQuestions.length})`,
+        }));
+        const research = await ai.generate({ prompt: subQuestions[i] });
+        subAnswers.push({ question: subQuestions[i], answer: research.text });
+      }
+      session.updateCustom((s) => ({ ...s!, subAnswers }));
+
+      // Step 3: synthesize and STREAM the final answer to the client.
+      session.updateCustom((s) => ({ ...s!, status: 'Synthesizing…' }));
+      const synthesis = ai.generateStream({
+        prompt: `Synthesize a unified answer from:\n${JSON.stringify(subAnswers)}`,
+      });
+      for await (const chunk of synthesis.stream) {
+        sendChunk({ modelChunk: chunk }); // stream model output to the client
+      }
+      const final = await synthesis.response;
+      lastMessage = final.message;
+
+      // Record the final response in the session history.
+      if (lastMessage) sess.addMessages([lastMessage]);
+      session.updateCustom((s) => ({ ...s!, status: 'Done' }));
+    });
+
+    return {
+      message: lastMessage ?? {
+        role: 'model' as const,
+        content: [{ text: 'Research complete.' }],
+      },
+    };
+  }
+);
+```
+
+## Custom status streaming
+
+Calling `session.updateCustom(...)` during the turn automatically emits a
+`customPatch` chunk, so the `remoteAgent` client's tracked
+[custom state](agents-state.md) (e.g. the `status` field) stays live **mid-stream**
+without any extra wiring. Stream model output separately with
+`sendChunk({ modelChunk })`.
+
+Seed and run a custom agent exactly like a regular one:
+
+```ts
+const chat = researchAgent.chat({
+  state: { custom: { subQuestions: [], subAnswers: [] }, messages: [], artifacts: [] },
+});
+const turn = chat.sendStream('Impacts of electric vehicles?');
+for await (const chunk of turn.stream) {
+  /* chunk.text for model output; chat.state.status for live progress */
+}
+await turn.response;
+```

--- a/skills/developing-genkit-js/references/agents-deployment.md
+++ b/skills/developing-genkit-js/references/agents-deployment.md
@@ -1,0 +1,190 @@
+# Deploying / Serving Agents over HTTP (Beta)
+
+> **Beta / preview API.** Uses `expressHandler` from `@genkit-ai/express` and the
+> agent's beta companion actions. Read [agents.md](agents.md) first.
+
+An agent is served as an HTTP endpoint with `expressHandler`. Most agents also
+expose two companion actions:
+
+- `agent.getSnapshotDataAction` → `POST /api/<name>/getSnapshot` — read a
+  snapshot's state. Needed for [snapshot restore](agents-branching.md) and
+  [background](agents-background.md) polling.
+- `agent.abortAgentAction` → `POST /api/<name>/abort` — cancel a
+  [background](agents-background.md) turn.
+
+These paths match the `remoteAgent` client defaults (`${url}/getSnapshot`,
+`${url}/abort`), so a client only needs the base `url`.
+
+## A reusable `exposeAgent` helper
+
+When serving several agents, a small helper keeps registration consistent.
+
+```ts
+import { expressHandler } from '@genkit-ai/express';
+import { Agent } from 'genkit/beta';
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+// Register an agent at `/api/<name>`, optionally wiring up its companion
+// `/getSnapshot` and `/abort` sub-actions.
+function exposeAgent(
+  name: string,
+  agent: Agent,
+  opts: { snapshot?: boolean; abort?: boolean } = {}
+) {
+  app.post(`/api/${name}`, expressHandler(agent));
+  if (opts.snapshot) {
+    app.post(
+      `/api/${name}/getSnapshot`,
+      expressHandler(agent.getSnapshotDataAction)
+    );
+  }
+  if (opts.abort) {
+    app.post(`/api/${name}/abort`, expressHandler(agent.abortAgentAction));
+  }
+}
+
+// Plain conversational agent — no companions needed:
+exposeAgent('weatherAgent', weatherAgent);
+
+// Snapshot restore / branching — needs getSnapshot:
+exposeAgent('branchingAgent', branchingAgent, { snapshot: true });
+
+// Background agent — needs both getSnapshot (polling) and abort:
+exposeAgent('backgroundAgent', backgroundAgent, { snapshot: true, abort: true });
+
+app.listen(process.env.PORT ? parseInt(process.env.PORT) : 8080);
+```
+
+Which companions to enable:
+
+| Agent capability                          | `snapshot` | `abort` |
+| ----------------------------------------- | ---------- | ------- |
+| Plain chat (client- or server-state)      | –          | –       |
+| Snapshot restore / [branching](agents-branching.md) | ✓ | –       |
+| [Background](agents-background.md) / detach | ✓        | ✓       |
+
+## CORS for browser clients
+
+A browser `remoteAgent` calling a different origin (e.g. a Vite dev server)
+needs CORS. **Streaming requires the `X-Genkit-Stream-Id` header** to be allowed
+on the request and exposed on the response.
+
+```ts
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Accept, X-Genkit-Stream-Id'
+  );
+  res.header('Access-Control-Expose-Headers', 'X-Genkit-Stream-Id');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(204);
+    return;
+  }
+  next();
+});
+```
+
+## Serving a static web UI (optional)
+
+To ship a single server that hosts both the API and a built SPA, serve the
+static bundle and add a non-`/api` fallback so client-side routing works on deep
+links / reloads.
+
+```ts
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const webDist = join(__dirname, '..', 'web', 'dist');
+if (existsSync(webDist)) {
+  app.use(express.static(webDist));
+  // SPA fallback — send index.html for any non-API GET request.
+  app.get(/^\/(?!api\/).*/, (_req, res) => {
+    res.sendFile(join(webDist, 'index.html'));
+  });
+}
+```
+
+## Registering agents/flows
+
+Agents and flows must be imported so they register with Genkit. Side-effect
+imports work, but explicitly referencing them makes the available actions clear:
+
+```ts
+import { weatherAgent } from './weather-agent.js';
+import { backgroundAgent } from './background-agent.js';
+
+// Force-reference so the modules' top-level defineAgent/defineFlow run.
+void [weatherAgent, backgroundAgent];
+```
+
+You can also expose plain flows the same way (e.g. helper endpoints):
+
+```ts
+app.post('/api/workspace/files', expressHandler(listWorkspaceFiles));
+```
+
+## Other host frameworks
+
+`expressHandler` is one of several adapters — an agent is just an action, so any
+of these works. Expose the companion actions
+(`agent.getSnapshotDataAction`, `agent.abortAgentAction`) at the matching
+sub-paths the same way when you need snapshot restore / background.
+
+### Next.js (`@genkit-ai/next`)
+
+`appRoute` turns an agent into an App Router route handler. Put companions in
+their own route files.
+
+```ts
+// app/api/weatherAgent/route.ts
+import { appRoute } from '@genkit-ai/next';
+import { weatherAgent } from '@/lib/agents';
+
+export const POST = appRoute(weatherAgent);
+
+// app/api/weatherAgent/getSnapshot/route.ts
+export const POST = appRoute(weatherAgent.getSnapshotDataAction);
+```
+
+### Web Fetch (`@genkit-ai/fetch`)
+
+Works with any Fetch-API runtime (Hono, Bun, Deno, Cloudflare Workers, Vercel/
+Netlify Edge, etc.). `fetchHandler(action)` returns `(request) => Promise<Response>`;
+`fetchHandlers(actions, prefix)` path-routes multiple actions by name.
+
+```ts
+import { fetchHandler } from '@genkit-ai/fetch';
+import { Hono } from 'hono';
+import { weatherAgent } from './agents.js';
+
+const app = new Hono();
+app.all('/api/weatherAgent', (c) => fetchHandler(weatherAgent)(c.req.raw));
+app.all('/api/weatherAgent/getSnapshot', (c) =>
+  fetchHandler(weatherAgent.getSnapshotDataAction)(c.req.raw)
+);
+```
+
+### Fastify (`@genkit-ai/fastify`)
+
+```ts
+import Fastify from 'fastify';
+import { fastifyHandler } from '@genkit-ai/fastify';
+import { weatherAgent } from './agents.js';
+
+const app = Fastify();
+app.post('/api/weatherAgent', fastifyHandler(weatherAgent));
+app.post(
+  '/api/weatherAgent/getSnapshot',
+  fastifyHandler(weatherAgent.getSnapshotDataAction)
+);
+await app.listen({ port: 8080 });
+```
+
+> The `@genkit-ai/vercel-ai` plugin additionally offers a `GenkitChatTransport`
+> for the Vercel AI SDK's `useChat`, which tracks the `chatId → snapshotId`
+> mapping for you (no client `SessionStore` needed).

--- a/skills/developing-genkit-js/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-js/references/agents-human-in-the-loop.md
@@ -1,0 +1,173 @@
+# Agent Human-in-the-Loop / Interrupts (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) first.
+
+An **interrupt** pauses an agent mid-turn and hands control back to your code (or
+a human) — e.g. to approve a sensitive action, collect missing input, or confirm
+a plan. Internally it's a **tool call used as control flow**: the interrupt tool
+never executes on the server; it exists only to pause the turn. You then
+**resume** from the exact point it paused.
+
+Interrupts are **orthogonal to persistence** — they work the same whether the
+agent uses a [session store](agents-sessions.md) or
+[client-managed state](agents.md#client-managed-state-no-server-store). The
+paused turn just needs to be carried back into the resume call: with a store the
+snapshot does it; without one the client round-trips the state blob (the
+`remoteAgent` client handles this for you).
+
+Flow: `chat.send(...)` → response has `res.interrupts` → collect human input →
+`chat.resume({ respond: [...] })`.
+
+## Define an interrupt
+
+Define it like a tool (with `inputSchema`/`outputSchema`) and add it to the
+agent's `tools`. No store is required; this example uses one so the multi-turn
+conversation also persists server-side.
+
+```ts
+import { z } from 'genkit';
+import { InMemorySessionStore } from 'genkit/beta';
+import { ai } from './genkit.js';
+
+export const userApproval = ai.defineInterrupt({
+  name: 'userApproval',
+  description: 'Ask the user for approval before a sensitive action.',
+  // What the model passes in when it pauses (shown to the human):
+  inputSchema: z.object({ action: z.string(), details: z.string() }),
+  // What the human/your code returns to resume:
+  outputSchema: z.object({
+    approved: z.boolean(),
+    feedback: z.string().optional(),
+  }),
+});
+
+export const transferMoney = ai.defineTool(
+  {
+    name: 'transferMoney',
+    description: 'Transfer money to a specified account.',
+    inputSchema: z.object({ amount: z.number(), toAccount: z.string() }),
+    outputSchema: z.object({ success: z.boolean(), transactionId: z.string() }),
+  },
+  async ({ amount, toAccount }) => ({
+    success: true,
+    transactionId: `txn-${Date.now()}`,
+  })
+);
+
+export const bankingAgent = ai.defineAgent({
+  name: 'bankingAgent',
+  system:
+    'You are a banking assistant. ALWAYS use the userApproval interrupt to ' +
+    'confirm before executing transferMoney.',
+  tools: [userApproval, transferMoney],
+  store: new InMemorySessionStore(),
+});
+```
+
+## Detect and resume (server-side)
+
+`res.interrupts` is non-empty when the agent paused. Each entry exposes:
+
+- `.name` — the interrupt's name.
+- `.input` — the data the model passed in (typed by the interrupt's `inputSchema`).
+- `.respond(output)` — **builder** returning a `toolResponse` part to resume with
+  (provides the tool's output without executing it). Does **not** send.
+- `.restart()` — **builder** re-issuing the original tool request (use to retry /
+  let the tool actually run). Does **not** send.
+
+Resume the **same** chat with `chat.resume(...)` (or `chat.resumeStream(...)`),
+which is sugar for `send({ resume })`:
+
+```ts
+const chat = bankingAgent.chat();
+let res = await chat.send('Transfer $500 to my savings account.');
+
+const approval = res.interrupts.find((i) => i.name === 'userApproval');
+if (approval) {
+  console.log(approval.input); // { action, details } — show this to the human
+
+  // Collect the human decision, then resume with the interrupt's output:
+  res = await chat.resume({
+    respond: [approval.respond({ approved: true, feedback: 'Looks good' })],
+  });
+}
+console.log(res.text); // final confirmation
+```
+
+Streaming variant:
+
+```ts
+const turn = chat.resumeStream({
+  respond: [approval.respond({ approved: true })],
+});
+for await (const chunk of turn.stream) process.stdout.write(chunk.text ?? '');
+const res = await turn.response;
+```
+
+You can resume multiple interrupts at once by passing several builders, and mix
+`respond` (supply output) with `restart` (re-run the tool):
+
+```ts
+await chat.resume({
+  respond: [a.respond({ approved: true })],
+  restart: [b.restart()],
+});
+```
+
+## Client-side (browser) interrupts
+
+The same pattern works over HTTP with `remoteAgent`. Types come from
+`genkit/beta/client`. The client tracks the snapshot, so resuming the same `chat`
+continues exactly where it paused.
+
+```ts
+import {
+  remoteAgent,
+  type AgentChat,
+  type AgentInterrupt,
+  type AgentResponse,
+} from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: '/api/bankingAgent' });
+const chat: AgentChat = agent.chat();
+
+// 1. Send and detect the pause.
+const res: AgentResponse = await chat.send('Transfer $500 to savings.');
+const pending: AgentInterrupt | undefined = res.interrupts.find(
+  (i) => i.name === 'userApproval'
+);
+
+if (pending) {
+  // pending.input → { action, details }; render an approval dialog.
+
+  // 2. After the human approves/denies, resume the SAME chat.
+  const respond = pending.respond({ approved: true, feedback: 'ok' });
+  const turn = chat.resumeStream({ respond: [respond] });
+  for await (const chunk of turn.stream) {
+    /* render chunk.text */
+  }
+  const final = await turn.response;
+  // If final.interrupts is non-empty, the agent paused again — repeat.
+}
+```
+
+> UX tip: don't render a model message bubble for an interrupted turn
+> (`res.interrupts.length > 0`); show the approval UI from `interrupt.input`
+> instead, then render the model's reply after resuming.
+
+## Notes & gotchas
+
+- **No store required.** Interrupts work with either a [session store](agents-sessions.md)
+  or [client-managed state](agents.md#client-managed-state-no-server-store) —
+  persistence is orthogonal. Just resume on the same `chat` (or, for raw calls,
+  carry the returned state/snapshot back into the resume).
+- **`respond`/`restart` are builders.** They return parts for the `resume`
+  payload; they do not send. You still call `chat.resume(...)`.
+- **Resume validation.** The server validates every `respond`/`restart` entry
+  against the conversation history (name/ref must match; `restart` input must be
+  unchanged). A mismatch is rejected — always build entries from the interrupt
+  objects in the response, not hand-rolled parts.
+- **Only `completed` snapshots are resumable.** A failed/aborted/pending snapshot
+  is kept for inspection but can't be resumed.
+- **Re-pausing.** After resuming, the new response may interrupt again; loop
+  until `res.interrupts` is empty.

--- a/skills/developing-genkit-js/references/agents-multi-agent.md
+++ b/skills/developing-genkit-js/references/agents-multi-agent.md
@@ -115,7 +115,8 @@ controls how they reach the orchestrator:
 
 `@genkit-ai/middleware` also exports `retry`, `fallback`, `filesystem`,
 `skills`, and `toolApproval`. They attach the same way via `use: [...]` on an
-agent (or on `ai.generate`). `retry()` is commonly paired with delegation:
+agent (or on `ai.generate`) — see [using middleware](middleware.md). `retry()`
+is commonly paired with delegation:
 
 ```ts
 import { retry } from '@genkit-ai/middleware';

--- a/skills/developing-genkit-js/references/agents-multi-agent.md
+++ b/skills/developing-genkit-js/references/agents-multi-agent.md
@@ -1,0 +1,136 @@
+# Multi-Agent Orchestration / Sub-Agents (Beta)
+
+> **Beta / preview API.** Sub-agent delegation uses the `agents()` middleware
+> from `@genkit-ai/middleware`. Read [agents.md](agents.md) first.
+
+A common pattern is an **orchestrator** agent that delegates tasks to
+specialized **sub-agents** (e.g. a `researcher` and a `coder`). The `agents()`
+middleware injects one delegation tool per sub-agent (`delegate_to_<name>`),
+appends a `<sub-agents>` block to the orchestrator's system prompt, and — when
+the model calls a delegation tool — runs the sub-agent and returns its response
+as the tool result.
+
+## 1. Define the sub-agents
+
+Give each sub-agent a `description` — it's auto-discovered and shown to the
+orchestrator so the model knows when to delegate.
+
+```ts
+import { artifacts, retry } from '@genkit-ai/middleware';
+import { ai, defaultModel } from './genkit.js';
+
+export const researcher = ai.defineAgent({
+  name: 'researcher',
+  description:
+    'A thorough research assistant that searches the web and provides ' +
+    'well-sourced answers.',
+  model: defaultModel,
+  system:
+    'You are a thorough research assistant. Save findings with write_artifact.',
+  maxTurns: 10,
+  use: [retry(), artifacts()],
+});
+
+export const coder = ai.defineAgent({
+  name: 'coder',
+  description: 'An expert programmer that writes clean, well-commented code.',
+  system: 'You are an expert programmer. Save code with write_artifact.',
+  maxTurns: 10,
+  use: [artifacts(), retry()],
+});
+```
+
+## 2. Wire up the orchestrator
+
+Add `agents()` to the orchestrator's `use: [...]`. Each entry is a name string
+(description auto-discovered) or `{ name, description }` to override.
+
+```ts
+import { agents, artifacts, retry } from '@genkit-ai/middleware';
+import { ai } from './genkit.js';
+
+export const orchestratorAgent = ai.defineAgent({
+  name: 'orchestratorAgent',
+  system: `You are a helpful project assistant. Analyze the request and
+delegate to the appropriate sub-agent. If it needs research AND code, call them
+sequentially, then synthesize a final answer.`,
+  use: [
+    agents({
+      agents: [
+        'researcher', // auto-discovered description
+        {
+          name: 'coder',
+          description: 'Writes, debugs, and explains code. Use for programming.',
+        },
+      ],
+      maxDelegations: 5, // guard rail against runaway delegation loops
+      historyLength: 4, // forward the last N user/model messages as context
+      artifactStrategy: 'session', // see "Sharing artifacts" below
+    }),
+    artifacts({ readonly: true }), // read sub-agent artifacts via read_artifact
+    retry(),
+  ],
+});
+```
+
+Run it like any other agent:
+
+```ts
+const chat = orchestratorAgent.chat();
+const turn = chat.sendStream(
+  'Research the best sorting algorithms, then write a TypeScript quicksort.'
+);
+for await (const chunk of turn.stream) process.stdout.write(chunk.text ?? '');
+const res = await turn.response;
+```
+
+## `agents()` options
+
+- `agents` (required): array of sub-agent refs. A `string` (name, description
+  auto-discovered from the registry) or `{ name, description? }` (explicit
+  override).
+- `toolPrefix`: prefix for generated tool names. Default `"delegate_to"` →
+  `delegate_to_<agent>`. Empty string uses bare agent names.
+- `maxDelegations`: max delegations per `generate` call. Prevents runaway loops.
+- `historyLength`: number of recent user/model messages forwarded to sub-agents
+  as context. `0`/omitted sends only the task description. (Only client-managed
+  sub-agents — no `store` — accept ad-hoc seeded history; server-managed
+  sub-agents skip it and just receive the task.)
+- `artifactStrategy`: `'inline'` (default) or `'session'` — see below.
+
+## Sharing artifacts between agents
+
+Sub-agents can produce [artifacts](agents-artifacts.md). `artifactStrategy`
+controls how they reach the orchestrator:
+
+- `'inline'` (default): artifact content is included in the delegation tool
+  result (so the model sees it directly) **and** merged into the parent session.
+- `'session'`: artifacts are merged into the parent session only; the tool
+  result lists artifact names, not content. Pair with the `artifacts()`
+  middleware so the orchestrator can `read_artifact` on demand (the pattern
+  shown above). Merged artifacts are namespaced by an invocation ID
+  (`<agentName>_<rand>/<name>`).
+
+## Other middleware
+
+`@genkit-ai/middleware` also exports `retry`, `fallback`, `filesystem`,
+`skills`, and `toolApproval`. They attach the same way via `use: [...]` on an
+agent (or on `ai.generate`). `retry()` is commonly paired with delegation:
+
+```ts
+import { retry } from '@genkit-ai/middleware';
+
+retry({
+  maxRetries: 3, // default 3
+  initialDelayMs: 1000, // default 1000
+  maxDelayMs: 60000, // default 60000
+  backoffFactor: 2, // default 2 (exponential backoff)
+  // statuses defaults to UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED,
+  // ABORTED, INTERNAL
+});
+```
+
+> Note: if a sub-agent triggers an [interrupt](agents-human-in-the-loop.md), it
+> is reported back to the orchestrator as a normal tool response (not propagated
+> as a resumable interrupt). Interactive, stateful sub-agent interrupts are a
+> future feature — delegate self-contained tasks.

--- a/skills/developing-genkit-js/references/agents-sessions.md
+++ b/skills/developing-genkit-js/references/agents-sessions.md
@@ -74,8 +74,11 @@ export const profileAgent = ai.defineAgent({
   stateSchema: Profile,
 });
 
-// Seed custom state when opening the chat:
-const chat = profileAgent.chat({ state: { name: 'Ada', tier: 'pro' } });
+// Seed custom state when opening the chat. Custom state lives under `.custom`
+// of the `SessionState` (that's what `stateSchema` validates).
+const chat = profileAgent.chat({
+  state: { custom: { name: 'Ada', tier: 'pro' } },
+});
 ```
 
 ## Interrupts (human-in-the-loop)

--- a/skills/developing-genkit-js/references/agents-sessions.md
+++ b/skills/developing-genkit-js/references/agents-sessions.md
@@ -1,0 +1,144 @@
+# Agent Sessions & Persistence (Beta)
+
+> **Beta / preview API.** Session stores are imported from `genkit/beta`
+> (`InMemorySessionStore`, `FileSessionStore`) and `@genkit-ai/google-cloud/beta`
+> (`FirestoreSessionStore`). See [agents.md](agents.md) for the basics first.
+
+When an agent has a `store`, the **server** owns the session history. Each turn
+produces an immutable **snapshot**; the snapshot chain is what carries
+conversation state forward. A store also enables [branching](agents-branching.md)
+and [background execution](agents-background.md). (Interrupts work with or without
+a store — see [human-in-the-loop](agents-human-in-the-loop.md).)
+
+## Pick a store
+
+```ts
+import { InMemorySessionStore, FileSessionStore } from 'genkit/beta';
+
+// In-memory: great for tests/dev; lost on restart.
+const memStore = new InMemorySessionStore();
+
+// File-backed: snapshots persisted under <dir>/global/<snapshotId>.json
+const fileStore = new FileSessionStore('./.snapshots');
+
+// File store with chain pruning — keep only the last N snapshots in a chain.
+const pruning = new FileSessionStore('./.snapshots', {
+  maxPersistedChainLength: 3,
+});
+```
+
+Attach it to the agent:
+
+```ts
+import { ai } from './genkit.js';
+
+export const logbookAgent = ai.defineAgent({
+  name: 'logbookAgent',
+  system: 'You are a personal logbook assistant.',
+  store: fileStore,
+});
+```
+
+A single `chat` persists to the store and threads the snapshot forward
+automatically:
+
+```ts
+const chat = logbookAgent.chat();
+const res1 = await chat.send('Log this: I started studying Genkit today.');
+const res2 = await chat.send('What did I study today?'); // remembers turn 1
+console.log(res1.snapshotId, res2.snapshotId);
+```
+
+Resume a prior conversation by snapshot id:
+
+```ts
+// Continue an existing session from its latest snapshot.
+const resumed = logbookAgent.chat({ snapshotId: res2.snapshotId });
+await resumed.send('Add another note.');
+```
+
+## Typed session state
+
+Use `stateSchema` to attach typed custom state to the session. `State` is
+inferred from the schema and validated when a snapshot is loaded.
+
+```ts
+import { z } from 'genkit';
+
+const Profile = z.object({ name: z.string(), tier: z.enum(['free', 'pro']) });
+
+export const profileAgent = ai.defineAgent({
+  name: 'profileAgent',
+  system: 'Greet the user by name and tailor answers to their tier.',
+  store: new InMemorySessionStore<z.infer<typeof Profile>>(),
+  stateSchema: Profile,
+});
+
+// Seed custom state when opening the chat:
+const chat = profileAgent.chat({ state: { name: 'Ada', tier: 'pro' } });
+```
+
+## Interrupts (human-in-the-loop)
+
+Interrupts pause a turn so a human can approve/provide input, then resume from
+the exact pause point. They work with a store or with client-managed state
+(persistence is orthogonal). See the dedicated reference:
+[Human-in-the-loop / interrupts](agents-human-in-the-loop.md).
+
+## Firestore session store (scalable, Beta)
+
+For production, `FirestoreSessionStore` (from `@genkit-ai/google-cloud/beta`)
+persists each turn as an incremental JSON Patch diff anchored to periodic sharded
+checkpoints — no single document approaches Firestore's 1 MiB limit, and
+reads/writes per turn are bounded by `checkpointInterval` rather than total
+session length (scales to long-lived chat/coding agents).
+
+```ts
+import { genkit } from 'genkit/beta';
+import { FirestoreSessionStore } from '@genkit-ai/google-cloud/beta';
+
+const ai = genkit({ plugins: [/* ... */] });
+
+const myAgent = ai.defineAgent({
+  name: 'myAgent',
+  system: 'You are a helpful assistant.',
+  // Defaults to a new Firestore() using Application Default Credentials.
+  store: new FirestoreSessionStore(),
+});
+```
+
+Options:
+
+- `db`: explicit Firestore instance (defaults to a new `Firestore()`, honoring
+  `FIRESTORE_EMULATOR_HOST`).
+- `collection`: snapshot collection (default `"genkit-sessions"`). Companion
+  collections `"<collection>-pointers"` and `"<collection>-shards"` are derived.
+- `checkpointInterval`: turns between full-state checkpoints (default `25`).
+  Lower for small, read-heavy state; raise for large per-turn state.
+- `shardSize`: max bytes per shard/diff document (default `512 KiB`).
+
+> On Firebase, `@genkit-ai/firebase` re-exports this store with Firebase app
+> setup (a `firebaseApp` option). See its README.
+
+## Implementing a custom `SessionStore`
+
+```ts
+import type { SessionStore } from 'genkit/beta';
+
+// S is the custom state type.
+const store: SessionStore<MyState> = {
+  // Load a snapshot by snapshotId OR sessionId (exactly one).
+  async getSnapshot(opts) {
+    /* ... */ return undefined;
+  },
+  // Atomically read → mutate → persist. Returns the snapshotId used,
+  // or null when the mutator returns null.
+  async saveSnapshot(snapshotId, mutator, options) {
+    /* ... */ return snapshotId ?? 'new-id';
+  },
+  // Optional: subscribe to snapshot state changes (used by background agents).
+  onSnapshotStateChange(snapshotId, callback, options) {
+    return () => {}; // unsubscribe
+  },
+};
+```

--- a/skills/developing-genkit-js/references/agents-state.md
+++ b/skills/developing-genkit-js/references/agents-state.md
@@ -1,0 +1,133 @@
+# Working with Agent State (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) first.
+
+Beyond message history, an agent session can hold typed **custom state** — your
+own structured data (a task list, a workflow status, counters, etc.). Tools read
+and mutate it during a turn, and it is automatically synced to the
+[`remoteAgent`](agents.md#consume-an-agent-from-a-client-remoteagent) client.
+
+## Declare the state shape
+
+Pass a `stateSchema` (Zod) to `defineAgent`. `State` is inferred from it and
+validated when a snapshot is loaded.
+
+```ts
+import { z } from 'genkit';
+import { ai } from './genkit.js';
+
+const TaskItem = z.object({
+  id: z.number(),
+  title: z.string(),
+  done: z.boolean(),
+});
+
+const TaskState = z.object({
+  tasks: z.array(TaskItem),
+  nextId: z.number(),
+});
+
+export const taskAgent = ai.defineAgent({
+  name: 'taskAgent',
+  stateSchema: TaskState,
+  system: 'You manage the user\'s task list. Use the tools to modify it.',
+  tools: [
+    /* addTask, toggleTask, removeTask — below */
+  ],
+});
+```
+
+## Read & mutate state inside tools
+
+Tools call `ai.currentSession<S>()` to access the live session, then
+`session.getCustom()` / `session.updateCustom(mutator)`. `updateCustom` takes
+`(custom?: S) => S` and returns the new state.
+
+```ts
+type TaskState = z.infer<typeof TaskState>;
+
+const addTask = ai.defineTool(
+  {
+    name: 'addTask',
+    description: 'Add a new task. Returns the created task.',
+    inputSchema: z.object({ title: z.string() }),
+    outputSchema: z.object({
+      id: z.number(),
+      title: z.string(),
+      done: z.boolean(),
+    }),
+  },
+  async (input) => {
+    const session = ai.currentSession<TaskState>();
+    let created!: { id: number; title: string; done: boolean };
+    session.updateCustom((state) => {
+      const s = state ?? { tasks: [], nextId: 1 };
+      created = { id: s.nextId, title: input.title, done: false };
+      s.tasks.push(created);
+      s.nextId++;
+      return s;
+    });
+    return created;
+  }
+);
+```
+
+`ai.currentSession()` throws if called outside an active session (e.g. a tool
+invoked without a running agent turn), so only use it inside agent tools.
+
+## Seed and read state (server-side)
+
+Seed initial custom state when opening a chat. The `state` argument is a
+`SessionState<S>`: custom data goes under `.custom` (alongside `messages` and
+`artifacts`).
+
+```ts
+const chat = taskAgent.chat({
+  state: {
+    custom: { tasks: [], nextId: 1 },
+    messages: [],
+    artifacts: [],
+  },
+});
+
+const res = await chat.send('Add a task: buy groceries');
+console.log(res.state); // res.state returns the custom state directly
+```
+
+## Auto-sync to the `remoteAgent` client
+
+When you talk to the agent over HTTP, the `remoteAgent` client tracks custom
+state for you. Parameterize the client with your state type, seed it the same
+way (`state.custom`), and after a turn read it off `chat.state`.
+
+**Important:** on the client, custom fields are **flattened directly onto
+`chat.state`** (e.g. `chat.state.tasks`) — not under `chat.state.custom`.
+
+```ts
+import { remoteAgent, type AgentChat } from 'genkit/beta/client';
+
+interface TaskState {
+  tasks: { id: number; title: string; done: boolean }[];
+  nextId: number;
+}
+
+const agent = remoteAgent<TaskState>({ url: '/api/taskAgent' });
+const chat: AgentChat<TaskState> = agent.chat({
+  state: { custom: { tasks: [], nextId: 1 }, messages: [], artifacts: [] },
+});
+
+const turn = chat.sendStream('Add buy groceries, then mark it done');
+for await (const chunk of turn.stream) {
+  /* render chunk.text */
+}
+await turn.response;
+
+// Custom state is flattened onto chat.state:
+console.log(chat.state?.tasks);
+```
+
+There is **no `onStateChange` subscription** — state updates ride on the
+streamed chunks. Read the authoritative state from `chat.state` after
+`await turn.response`. (For live mid-stream status updates from a custom agent,
+see [advanced custom agents](agents-custom.md), which emit `customPatch` chunks
+as state changes.)

--- a/skills/developing-genkit-js/references/agents.md
+++ b/skills/developing-genkit-js/references/agents.md
@@ -25,6 +25,7 @@ Progressive disclosure — read the file for the level you need:
 - [Artifacts](agents-artifacts.md): producing/reading named deliverables.
 - [Multi-agent orchestration](agents-multi-agent.md): delegating to sub-agents.
 - [Advanced custom agents](agents-custom.md): `defineCustomAgent` for full turn control.
+- [Deploying agents](agents-deployment.md): serving multiple agents over HTTP, CORS, web UI, other frameworks.
 
 ## Setup
 
@@ -131,6 +132,10 @@ app.post(
 
 app.listen(8080);
 ```
+
+For serving multiple agents, CORS/streaming headers for browser clients, a static
+web UI, and other host frameworks (Next.js, Firebase), see
+[Deploying agents](agents-deployment.md).
 
 ## Consume an agent from a client (`remoteAgent`)
 

--- a/skills/developing-genkit-js/references/agents.md
+++ b/skills/developing-genkit-js/references/agents.md
@@ -3,6 +3,8 @@
 > **Beta / preview API.** Agents are not yet stable. Server APIs come from
 > `genkit/beta`; the browser client comes from `genkit/beta/client`. Import paths
 > and signatures may change. Always use `genkit/beta`, not `genkit`, for agents.
+>
+> **Requires `genkit` >= 1.39.0.**
 
 An **agent** is a persistent, multi-turn conversation primitive built on top of
 prompts + tools. Compared to a bare `ai.generate`/`ai.definePrompt` loop, an

--- a/skills/developing-genkit-js/references/agents.md
+++ b/skills/developing-genkit-js/references/agents.md
@@ -1,0 +1,208 @@
+# Agents (Beta)
+
+> **Beta / preview API.** Agents are not yet stable. Server APIs come from
+> `genkit/beta`; the browser client comes from `genkit/beta/client`. Import paths
+> and signatures may change. Always use `genkit/beta`, not `genkit`, for agents.
+
+An **agent** is a persistent, multi-turn conversation primitive built on top of
+prompts + tools. Compared to a bare `ai.generate`/`ai.definePrompt` loop, an
+agent adds:
+
+- **Sessions**: multi-turn history tracked as immutable **snapshots**.
+- **State**: typed session state (messages + custom data + artifacts).
+- **Interrupts**: human-in-the-loop pause/resume.
+- **Branching**: fork a conversation from any snapshot.
+- **Detaching**: run a turn in the background and poll for the result.
+
+Progressive disclosure — read the file for the level you need:
+
+- This file: defining an agent, serving it, and **client-managed state** (no store).
+- [Sessions & persistence](agents-sessions.md): `SessionStore`, `InMemorySessionStore`, `FileSessionStore`, `FirestoreSessionStore`.
+- [Human-in-the-loop / interrupts](agents-human-in-the-loop.md): pausing for approval/input and resuming.
+- [Branching](agents-branching.md): forking a conversation from a snapshot.
+- [Background agents](agents-background.md): detaching long-running turns and polling.
+
+## Setup
+
+```ts
+// genkit.ts — note the `genkit/beta` import (required for agents)
+import { genkit } from 'genkit/beta';
+import { googleAI } from '@genkit-ai/google-genai';
+
+export const ai = genkit({
+  plugins: [googleAI()],
+  model: googleAI.model('gemini-flash-latest'),
+});
+```
+
+## Define an agent
+
+`ai.defineAgent` combines prompt + tool config + (optional) session store into a
+single registered action.
+
+```ts
+import { z } from 'genkit';
+import { ai } from './genkit.js';
+
+const getWeather = ai.defineTool(
+  {
+    name: 'getWeather',
+    description: 'Look up the current weather for a city.',
+    inputSchema: z.object({ city: z.string() }),
+    outputSchema: z.object({ tempC: z.number(), summary: z.string() }),
+  },
+  async ({ city }) => ({ tempC: 21, summary: 'Sunny' })
+);
+
+export const weatherAgent = ai.defineAgent({
+  name: 'weatherAgent',
+  system:
+    'You are a helpful weather assistant. Use the getWeather tool. Be concise.',
+  tools: [getWeather],
+  // `store` is optional. Omit it for client-managed state (see below).
+});
+```
+
+Common `defineAgent` options:
+
+- `name` (required): action name.
+- `system` / `prompt` / dotprompt fields: same as `definePrompt`.
+- `tools`: tools and interrupts available to the agent.
+- `model`: override the default model.
+- `store`: a `SessionStore` for server-side persistence. See [sessions](agents-sessions.md).
+- `stateSchema`: a `z.ZodType<State>` describing custom session state. When set,
+  `State` is inferred and validated at load time.
+- `input` / `inputSchema`: input variables for the prompt template.
+
+## Chat with an agent (server-side)
+
+`agent.chat()` opens a conversation. A single `chat` carries state forward
+automatically across turns.
+
+```ts
+const chat = weatherAgent.chat();
+
+// Non-streaming turn:
+const res = await chat.send('Weather in Tokyo?');
+console.log(res.text);
+console.log(res.snapshotId); // immutable checkpoint id for this turn
+
+// Follow-up turn — history is carried automatically:
+const res2 = await chat.send('What about Paris?');
+
+// Streaming turn:
+const turn = chat.sendStream('And London?');
+for await (const chunk of turn.stream) {
+  process.stdout.write(chunk.text ?? '');
+}
+const final = await turn.response;
+```
+
+## Serve an agent over HTTP
+
+Use `expressHandler` from `@genkit-ai/express`. Optionally expose the agent's
+companion `getSnapshotDataAction` (for state lookup/restore) and
+`abortAgentAction` (for background aborts).
+
+```ts
+import { expressHandler } from '@genkit-ai/express';
+import express from 'express';
+import { weatherAgent } from './weather-agent.js';
+
+const app = express();
+app.use(express.json());
+
+// Main turn endpoint:
+app.post('/api/weatherAgent', expressHandler(weatherAgent));
+
+// Optional companions (needed for snapshot restore / branching / background):
+app.post(
+  '/api/weatherAgent/getSnapshot',
+  expressHandler(weatherAgent.getSnapshotDataAction)
+);
+app.post(
+  '/api/weatherAgent/abort',
+  expressHandler(weatherAgent.abortAgentAction)
+);
+
+app.listen(8080);
+```
+
+## Consume an agent from a client (`remoteAgent`)
+
+The browser/Node client lives in `genkit/beta/client`. `remoteAgent` returns a
+typed HTTP client; `getSnapshotUrl`/`abortUrl` default to `${url}/getSnapshot`
+and `${url}/abort`.
+
+```ts
+import { remoteAgent, AgentError } from 'genkit/beta/client';
+
+const weather = remoteAgent({ url: 'http://localhost:8080/api/weatherAgent' });
+
+const chat = weather.chat();
+const turn = chat.sendStream('Weather in Tokyo?');
+for await (const chunk of turn.stream) {
+  process.stdout.write(chunk.text ?? '');
+}
+const res = await turn.response;
+console.log(res.snapshotId, chat.snapshotId, chat.state);
+
+// Multi-turn — the client carries state forward automatically:
+await chat.send('What about Paris?');
+
+// Errors surface as AgentError with an HTTP-ish status:
+try {
+  await remoteAgent({ url: '/api/nope' }).chat().send('hi');
+} catch (err) {
+  if (err instanceof AgentError) console.log(err.status);
+}
+```
+
+## Client-managed state (no server store)
+
+If the agent has **no `store`**, the server is fully stateless and the session
+state blob (messages + custom + artifacts) is owned by the caller. The
+`remoteAgent` client tracks it and round-trips it on every turn automatically —
+no `SessionStore`, no snapshot ids to manage.
+
+```ts
+// Server: no `store` → stateless. Client owns the state blob.
+export const weatherAgentStateless = ai.defineAgent({
+  name: 'weatherAgentStateless',
+  system: 'You are a helpful weather assistant. Use getWeather. Be concise.',
+  tools: [getWeather],
+});
+```
+
+```ts
+// Client: reuse one `chat` and the state threads automatically.
+import { remoteAgent, type AgentChat } from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: '/api/weatherAgentStateless' });
+const chat: AgentChat = agent.chat();
+
+await chat.send('Weather in London?');
+await chat.send('Is it sunny in Tokyo?'); // remembers prior turns
+
+// The full state blob is available after each turn:
+const res = await chat.send('And Paris?');
+console.log(JSON.stringify(res.raw.state, null, 2));
+```
+
+If you call the stateless agent directly (e.g. from a flow) instead of via
+`remoteAgent`, you must round-trip the state yourself:
+
+```ts
+async function turn(state: unknown | undefined, text: string) {
+  // Resume from prior state, or start fresh on the first turn.
+  const chat = weatherAgentStateless.chat(state ? { state } : undefined);
+  const res = await chat.send(text);
+  // Return the updated state so the caller can pass it back next turn.
+  return { state: res.raw.state, text: res.text };
+}
+```
+
+Use client-managed state when you don't want to run server-side storage (e.g.
+the client persists history itself). Use a [session store](agents-sessions.md)
+when the server should own history, or when you need branching or background
+execution. ([Interrupts](agents-human-in-the-loop.md) work either way.)

--- a/skills/developing-genkit-js/references/agents.md
+++ b/skills/developing-genkit-js/references/agents.md
@@ -79,6 +79,47 @@ Common `defineAgent` options:
   `State` is inferred and validated at load time.
 - `input` / `inputSchema`: input variables for the prompt template.
 
+## Agents and middleware go hand in hand
+
+Agents and [middleware](middleware.md) are built for each other: the `use: [...]`
+array is where you layer in sophisticated behavior without writing it yourself.
+Most agent capabilities — sub-agent delegation, artifacts, filesystem access,
+skill loading, tool approval, retries — are just middleware you drop in.
+
+For example, a full coding assistant is mostly configuration:
+
+```ts
+import { filesystem, retry, skills, toolApproval } from '@genkit-ai/middleware';
+import { FileSessionStore } from 'genkit/beta';
+import { ai } from './genkit.js';
+
+export const codingAgent = ai.defineAgent({
+  name: 'codingAgent',
+  system: 'You are an expert AI coding assistant working in a sandboxed workspace.',
+  tools: [runShell, askUser], // your own custom tools/interrupts
+  use: [
+    // Require user approval (interrupt) before risky tools; reads auto-approved.
+    // Order matters: keep toolApproval before filesystem.
+    toolApproval({
+      approved: ['list_files', 'read_file', 'use_skill', 'run_shell', 'ask_user'],
+    }),
+    // list_files / read_file / write_file / search_and_replace, sandboxed.
+    filesystem({ rootDirectory: WORKSPACE_DIR, allowWriteAccess: true }),
+    // Load coding conventions on demand via a use_skill tool.
+    skills({ skillPaths: [SKILLS_DIR] }),
+    // Automatic retry on transient model errors.
+    retry(),
+  ],
+  store: new FileSessionStore('./.snapshots-coding'), // needed for tool approval
+  maxTurns: 30,
+});
+```
+
+That single `use` array gives the agent filesystem tools, an on-demand skills
+library, human-in-the-loop approval for writes, and retries — each is one line.
+See [using middleware](middleware.md) for the full catalog and
+[building custom middleware](middleware-custom.md) to write your own.
+
 ## Chat with an agent (server-side)
 
 `agent.chat()` opens a conversation. A single `chat` carries state forward

--- a/skills/developing-genkit-js/references/agents.md
+++ b/skills/developing-genkit-js/references/agents.md
@@ -21,6 +21,10 @@ Progressive disclosure — read the file for the level you need:
 - [Human-in-the-loop / interrupts](agents-human-in-the-loop.md): pausing for approval/input and resuming.
 - [Branching](agents-branching.md): forking a conversation from a snapshot.
 - [Background agents](agents-background.md): detaching long-running turns and polling.
+- [Working with state](agents-state.md): typed custom session state and client auto-sync.
+- [Artifacts](agents-artifacts.md): producing/reading named deliverables.
+- [Multi-agent orchestration](agents-multi-agent.md): delegating to sub-agents.
+- [Advanced custom agents](agents-custom.md): `defineCustomAgent` for full turn control.
 
 ## Setup
 

--- a/skills/developing-genkit-js/references/middleware-custom.md
+++ b/skills/developing-genkit-js/references/middleware-custom.md
@@ -1,0 +1,96 @@
+# Building Custom Middleware
+
+Write reusable, named middleware with `generateMiddleware`. It returns a factory
+you call in the `use: [...]` array (see [using middleware](middleware.md)) —
+exactly how the `@genkit-ai/middleware` package's middleware are built. The
+factory can take optional Zod-validated config and gets access to the `ai`
+instance.
+
+```ts
+// timing.ts
+import { generateMiddleware, z } from 'genkit';
+
+const OptionsSchema = z.object({ label: z.string().optional() });
+
+export const timing = generateMiddleware(
+  {
+    name: 'timing',
+    description: 'Logs how long the model call takes.',
+    configSchema: OptionsSchema,
+  },
+  ({ config, ai }) => {
+    // Runs once per generate() call. Return any of the hooks below.
+    return {
+      model: async (req, ctx, next) => {
+        const start = Date.now();
+        const res = await next(req, ctx);
+        console.log(`[${config?.label ?? 'timing'}] ${Date.now() - start}ms`);
+        return res;
+      },
+    };
+  }
+);
+```
+
+## Register it as a plugin
+
+Register custom middleware with Genkit via its `.plugin()` method. This is the
+recommended setup — without it the middleware still works in `use: [...]`, but it
+is **not visible to the Genkit Dev UI**.
+
+```ts
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+import { timing } from './timing.js';
+
+export const ai = genkit({
+  plugins: [googleAI(), timing.plugin()],
+});
+
+// Then use the factory in `use: [...]`:
+await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Hi',
+  use: [timing({ label: 'gen' })],
+});
+```
+
+## Available hooks
+
+The instantiate callback returns a `GenerateMiddlewareDef` with any subset of:
+
+- `generate(envelope, ctx, next)` — wrap the **whole generate action**. The
+  `envelope` carries `{ request, currentTurn, messageIndex }`. Use it to inject
+  request params, post-process the response, or catch errors across the tool loop.
+- `model(req, ctx, next)` — wrap the **underlying model call** (caching, retry,
+  request/response rewriting). `req` is a `GenerateRequest`.
+- `tool(req, ctx, next)` — wrap **individual tool calls** (validate inputs,
+  cache or override tool output). `req` is a `ToolRequestPart`; return a
+  `ToolResponsePart | undefined`.
+- `tools: ToolAction[]` — **statically inject tools** whenever the middleware is
+  active (how `artifacts()` / `filesystem()` add their tools).
+
+```ts
+generateMiddleware({ name: 'example' }, ({ ai }) => ({
+  generate: async (envelope, ctx, next) => next(envelope, ctx),
+  model: async (req, ctx, next) => next(req, ctx),
+  tool: async (req, ctx, next) => next(req, ctx),
+  tools: [
+    /* ToolAction[] */
+  ],
+}));
+```
+
+Call `next(...)` to continue the chain (optionally with a modified
+request/envelope) and transform the result before returning it.
+
+## Choosing a hook
+
+- Transform prompt/messages or the final result across the whole turn → `generate`.
+- Cache/retry/rewrite a single model round-trip → `model`.
+- Gate or memoize tool execution → `tool`.
+- Make extra capabilities available to the model → `tools`.
+
+> Reminder: register custom middleware via `.plugin()` (see above). It works in
+> `use: [...]` without registering, but unregistered middleware is not visible to
+> the Genkit Dev UI.

--- a/skills/developing-genkit-js/references/middleware.md
+++ b/skills/developing-genkit-js/references/middleware.md
@@ -1,0 +1,170 @@
+# Using Middleware
+
+Middleware wraps generation to add cross-cutting behavior — retries, fallback,
+extra tools, request/response transforms, etc. You attach middleware with the
+`use: [...]` array, which is supported on `ai.generate` / `ai.generateStream`,
+executable prompts (`definePrompt`), and agents (`defineAgent`).
+
+```ts
+import { retry } from '@genkit-ai/middleware';
+
+const res = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Say hello',
+  use: [retry({ maxRetries: 2 })],
+});
+```
+
+The same array works on prompts and agents:
+
+```ts
+const myPrompt = ai.definePrompt({ name: 'p', prompt: '...', use: [retry()] });
+
+const myAgent = ai.defineAgent({ name: 'a', system: '...', use: [retry()] });
+```
+
+Middleware is a configurable factory like `retry()` / `artifacts()` that returns
+a reference for `use: [...]`. The `@genkit-ai/middleware` package ships a set of
+ready-made ones (covered below); to write your own see
+[building custom middleware](middleware-custom.md).
+
+## Register middleware as a plugin
+
+Register each middleware with Genkit via its `.plugin()` method. This is the
+recommended setup — middleware still works in `use: [...]` without registering,
+but **unregistered middleware is not visible to the Genkit Dev UI**.
+
+```ts
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+import { retry, artifacts } from '@genkit-ai/middleware';
+
+export const ai = genkit({
+  plugins: [googleAI(), retry.plugin(), artifacts.plugin()],
+});
+
+// Then reference the factory in `use: [...]`:
+await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Say hello',
+  use: [retry({ maxRetries: 2 })],
+});
+```
+
+## The `@genkit-ai/middleware` package
+
+```bash
+npm i @genkit-ai/middleware
+```
+
+Exports seven middleware factories. Register each via `.plugin()` (above), then
+call `name(options)` in `use: [...]`.
+
+### `retry(options?)`
+
+Retries on transient errors with exponential backoff.
+
+```ts
+import { retry } from '@genkit-ai/middleware';
+
+retry({
+  maxRetries: 3, // default 3
+  initialDelayMs: 1000, // default 1000
+  maxDelayMs: 60000, // default 60000
+  backoffFactor: 2, // default 2
+  noJitter: false, // default false
+  // statuses defaults to UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED,
+  // ABORTED, INTERNAL
+});
+```
+
+### `fallback(options)`
+
+Falls back to other models when the primary fails.
+
+```ts
+import { fallback } from '@genkit-ai/middleware';
+import { googleAI } from '@genkit-ai/google-genai';
+
+fallback({
+  models: [googleAI.model('gemini-flash-latest')], // tried in order
+  // statuses defaults to UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED,
+  // ABORTED, INTERNAL, NOT_FOUND, UNIMPLEMENTED
+  isolateConfig: false, // default false — fallback inherits the request config
+});
+```
+
+### `artifacts(options?)`
+
+Adds `write_artifact` / `read_artifact` tools for session artifacts.
+
+```ts
+artifacts({ readonly: false }); // readonly true → read_artifact only
+```
+
+See [working with artifacts](agents-artifacts.md).
+
+### `agents(options)`
+
+Sub-agent delegation — injects a `delegate_to_<name>` tool per sub-agent.
+
+```ts
+agents({ agents: ['researcher', 'coder'], maxDelegations: 5 });
+```
+
+See [multi-agent orchestration](agents-multi-agent.md).
+
+### `filesystem(options)`
+
+Grants the model `list_files`, `read_file`, `write_file`, and
+`search_and_replace` tools, sandboxed to a root directory.
+
+```ts
+filesystem({
+  rootDirectory: './workspace', // required; all access is restricted to it
+  allowWriteAccess: false, // default false (read-only)
+  toolNamePrefix: '', // optional prefix for the injected tool names
+});
+```
+
+### `skills(options?)`
+
+Scans directories for skill files (frontmatter `name`/`description`), injects a
+listing into the system prompt, and provides a `use_skill` tool.
+
+```ts
+skills({ skillPaths: ['skills'] }); // default ['skills']
+```
+
+### `toolApproval(options)`
+
+Restricts tool execution to an approved list; throws a `ToolInterruptError` for
+anything else (resumable via [interrupts](agents-human-in-the-loop.md)).
+
+```ts
+toolApproval({ approved: ['getWeather', 'search'] });
+```
+
+## Built-in model middleware (in core)
+
+Some middleware ships in the `genkit` core (no extra package) — import from
+`genkit/model/middleware`:
+
+- `downloadRequestMedia({ maxBytes? })` — fetch URL media and inline it.
+- `validateSupport({ name, ... })` — assert a model supports requested features.
+- `simulateSystemPrompt({ preface? })` — emulate a system prompt for models
+  without native support.
+- `augmentWithContext(options?)` — inject retrieved context documents.
+- `simulateConstrainedGeneration(options?)` — emulate constrained/JSON output.
+
+```ts
+import { simulateConstrainedGeneration } from 'genkit/model/middleware';
+
+await ai.generate({
+  model: someModel,
+  prompt: '...',
+  use: [simulateConstrainedGeneration()],
+});
+```
+
+To write your own, see [building custom middleware](middleware-custom.md).


### PR DESCRIPTION
Add documentation covering Genkit's beta agent API, including sections on agents, sessions/persistence, human-in-the-loop interrupts, branching, and background agents. Also add `scratch` to .gitignore.