### PR TITLE
docs: add Agents section to Genkit Dart skill

### DIFF
--- a/skills/developing-genkit-dart/SKILL.md
+++ b/skills/developing-genkit-dart/SKILL.md
@@ -11,6 +11,15 @@ Genkit Dart is an AI SDK for Dart that provides a unified interface for code gen
 If you need help with initializing Genkit (`Genkit()`), Generation (`ai.generate`), Tooling (`ai.defineTool`), Flows (`ai.defineFlow`), Embeddings (`ai.embedMany`), streaming, or calling remote flow endpoints, please load the core framework reference: 
 [references/genkit.md](references/genkit.md)
 
+## Prompts (Dotprompt)
+
+`.prompt` files keep prompt content out of Dart code with YAML frontmatter plus a
+Handlebars template. See [references/dotprompt.md](references/dotprompt.md):
+`promptDir`, `ai.prompt()` (call/stream/render), variants, partials, named
+schemas via `defineSchema`, and the `tools`/`maxTurns`/`returnToolRequests`/`use`
+(middleware) frontmatter fields. A `.prompt` file can also back an agent directly
+via `definePromptAgent`.
+
 ## Agents
 
 Genkit Dart has an **agent** API for persistent, multi-turn conversations
@@ -57,9 +66,6 @@ Wrap your run command with `genkit start` to attach the Genkit developer UI and 
 genkit start -- dart run main.dart
 
 # Run a flow directly from the CLI
-genkit flow:run myFlow '{"data": "input"}'
-
-# Or run the flow and spin up the runtime in a single command
 genkit flow:run myFlow '{"data": "input"}' -- dart run main.dart
 
 # Tracing

--- a/skills/developing-genkit-dart/SKILL.md
+++ b/skills/developing-genkit-dart/SKILL.md
@@ -11,6 +11,30 @@ Genkit Dart is an AI SDK for Dart that provides a unified interface for code gen
 If you need help with initializing Genkit (`Genkit()`), Generation (`ai.generate`), Tooling (`ai.defineTool`), Flows (`ai.defineFlow`), Embeddings (`ai.embedMany`), streaming, or calling remote flow endpoints, please load the core framework reference: 
 [references/genkit.md](references/genkit.md)
 
+## Agents
+
+Genkit Dart has an **agent** API for persistent, multi-turn conversations
+(sessions, snapshots, interrupts, branching, background execution, custom state,
+artifacts, and multi-agent delegation). Server APIs come from
+`package:genkit/genkit.dart` and the browser/HTTP client from
+`package:genkit/client.dart`. A few Dart specifics: interrupts are modeled as
+tools that call `ctx.interrupt(...)` (there is no `defineInterrupt`), sub-agent
+delegation uses the `agents()` middleware from `package:genkit_middleware`, and
+there is no `artifacts()` middleware yet (define artifact tools directly).
+
+For more details see:
+
+-   [Agents](references/agents.md): defining/serving an agent and client-managed state (start here).
+-   [Sessions & persistence](references/agents-sessions.md): session stores (`InMemorySessionStore`/`FileSessionStore`/`FirestoreSessionStore`).
+-   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input via `ctx.interrupt` and resuming.
+-   [Branching](references/agents-branching.md): forking a conversation from a snapshot.
+-   [Background agents](references/agents-background.md): detaching long-running turns and polling.
+-   [Working with state](references/agents-state.md): typed custom session state, auto-synced to the client.
+-   [Artifacts](references/agents-artifacts.md): producing and reading named deliverables.
+-   [Multi-agent orchestration](references/agents-multi-agent.md): delegating to sub-agents with the `agents()` middleware.
+-   [Advanced custom agents](references/agents-custom.md): `defineCustomAgent` for full turn control.
+-   [Deploying agents](references/agents-deployment.md): serving agents over HTTP with `genkit_shelf` (multiple agents, CORS).
+
 ## Genkit CLI (recommended)
 
 The Genkit CLI provides a local development UI for running Flow, tracing executions, playing with models, and evaluating outputs.

--- a/skills/developing-genkit-dart/SKILL.md
+++ b/skills/developing-genkit-dart/SKILL.md
@@ -17,10 +17,13 @@ Genkit Dart has an **agent** API for persistent, multi-turn conversations
 (sessions, snapshots, interrupts, branching, background execution, custom state,
 artifacts, and multi-agent delegation). Server APIs come from
 `package:genkit/genkit.dart` and the browser/HTTP client from
-`package:genkit/client.dart`. A few Dart specifics: interrupts are modeled as
-tools that call `ctx.interrupt(...)` (there is no `defineInterrupt`), sub-agent
-delegation uses the `agents()` middleware from `package:genkit_middleware`, and
-there is no `artifacts()` middleware yet (define artifact tools directly).
+`package:genkit/client.dart`. The `remoteAgent` client works from any Dart app,
+including **Flutter**, and the backend is fully interchangeable — it can talk to
+a Genkit agent implemented in Dart, JS/TypeScript, or Go over the same HTTP
+protocol. A few Dart specifics: interrupts are modeled as tools that call
+`ctx.interrupt(...)` (there is no `defineInterrupt`), sub-agent delegation uses
+the `agents()` middleware from `package:genkit_middleware`, and there is no
+`artifacts()` middleware yet (define artifact tools directly).
 
 For more details see:
 

--- a/skills/developing-genkit-dart/references/agents-artifacts.md
+++ b/skills/developing-genkit-dart/references/agents-artifacts.md
@@ -97,7 +97,7 @@ Run it; artifacts are produced via the tool and returned in the response:
 
 ```dart
 final chat = workspaceAgent.chat();
-final res = await chat.sendText('Write poem.txt with a poem about Genkit');
+final res = await chat.send(text: 'Write poem.txt with a poem about Genkit');
 print(res.artifacts); // List<Artifact>
 ```
 
@@ -142,7 +142,7 @@ import 'package:genkit/client.dart';
 final agent = remoteAgent(url: '/api/workspaceAgent');
 final chat = agent.chat();
 
-final turn = chat.sendTextStream('Create index.html and styles.css');
+final turn = chat.sendStream(text: 'Create index.html and styles.css');
 await for (final chunk in turn.stream) {
   final artifact = chunk.artifact;
   if (artifact != null) {

--- a/skills/developing-genkit-dart/references/agents-artifacts.md
+++ b/skills/developing-genkit-dart/references/agents-artifacts.md
@@ -12,6 +12,18 @@ name) and are returned in `res.artifacts` / tracked on the client's
 > `read_artifact` tools directly on top of the session artifact API
 > (`ai.currentSession().addArtifacts()` / `getArtifacts()`).
 
+> **Session artifacts vs. real files.** Artifacts (this page) live *in the
+> session state* — they travel with the conversation and stream to the client.
+> If instead you want the agent to work against **real files on disk** (a
+> sandboxed workspace), use the `filesystem()` middleware from
+> `package:genkit_middleware/filesystem.dart`
+> (`filesystem(rootDirectory: ...)`, backed by `FilesystemPlugin()`), which
+> gives the model `list_files` / `read_file` / `write_file` /
+> `search_and_replace` tools rooted at a directory. See
+> [middleware](genkit_middleware.md). The two approaches are complementary:
+> session artifacts for conversation-scoped deliverables, `filesystem()` for
+> persistent on-disk work.
+
 ## Give the model artifact tools
 
 ```dart

--- a/skills/developing-genkit-dart/references/agents-artifacts.md
+++ b/skills/developing-genkit-dart/references/agents-artifacts.md
@@ -1,0 +1,147 @@
+# Working with Artifacts
+
+> The `Artifact` type comes from `package:genkit/genkit.dart`. Read
+> [agents.md](agents.md) first.
+
+**Artifacts** are named, content-bearing deliverables an agent produces during a
+session — files, reports, code, etc. They live in the session (deduplicated by
+name) and are returned in `res.artifacts` / tracked on the client's
+`chat.artifacts`.
+
+> **Dart has no `artifacts()` middleware yet.** Define `write_artifact` /
+> `read_artifact` tools directly on top of the session artifact API
+> (`ai.currentSession().addArtifacts()` / `getArtifacts()`).
+
+## Give the model artifact tools
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+part 'workspace_agent.g.dart';
+
+@Schema()
+abstract class $WriteArtifactInput {
+  @Field(description: 'The name (e.g. filename) of the artifact.')
+  String get name;
+  @Field(description: 'The full content of the artifact.')
+  String get content;
+}
+
+@Schema()
+abstract class $ReadArtifactInput {
+  @Field(description: 'The name of the artifact to read.')
+  String get name;
+}
+
+final writeArtifact = ai.defineTool(
+  name: 'write_artifact',
+  description: 'Create or overwrite a named artifact (e.g. a file). Pass the '
+      'filename as "name" and the full content as "content".',
+  inputSchema: WriteArtifactInput.$schema,
+  outputSchema: SchemanticType.string(),
+  fn: (input, _) async {
+    final session = ai.currentSession()!;
+    session.addArtifacts([
+      Artifact(name: input.name, parts: [TextPart(text: input.content)]),
+    ]);
+    return 'Wrote artifact "${input.name}".';
+  },
+);
+
+final readArtifact = ai.defineTool(
+  name: 'read_artifact',
+  description: 'Read the content of a previously created artifact by name.',
+  inputSchema: ReadArtifactInput.$schema,
+  outputSchema: SchemanticType.string(),
+  fn: (input, _) async {
+    final session = ai.currentSession()!;
+    final match = session.getArtifacts().where((a) => a.name == input.name);
+    if (match.isEmpty) return 'Artifact "${input.name}" not found.';
+    return match.first.parts.map((p) => p.text ?? '').join();
+  },
+);
+
+final workspaceAgent = ai.defineAgent(
+  name: 'workspaceAgent',
+  system: 'You are a code generation assistant. Use write_artifact to create '
+      'files (pass the filename as "name" and the full content as "content"). '
+      'Use read_artifact to review or modify a previously created file.',
+  tools: [writeArtifact, readArtifact],
+  use: [retry()],
+  store: InMemorySessionStore(),
+);
+```
+
+## How artifacts flow
+
+Adding an artifact to the session emits an event that the agent runtime forwards
+to the client as an `artifact` stream chunk. Artifacts are **deduplicated by
+name** — writing the same `name` again replaces it.
+
+Run it; artifacts are produced via the tool and returned in the response:
+
+```dart
+final chat = workspaceAgent.chat();
+final res = await chat.sendText('Write poem.txt with a poem about Genkit');
+print(res.artifacts); // List<Artifact>
+```
+
+## The `Artifact` shape
+
+```dart
+// An artifact's content lives in `parts` (text parts). `name` and `metadata`
+// are optional on the type but you should always set `name`.
+final artifact = Artifact(
+  name: 'poem.txt',
+  parts: [TextPart(text: 'Roses are red…')],
+);
+```
+
+## Programmatic access (inside tools / custom agents)
+
+Use the active session. `ai.currentSession()` returns `null` when there's no
+active session, so only call it inside an agent turn.
+
+```dart
+final session = ai.currentSession()!;
+
+// Read all artifacts:
+final all = session.getArtifacts(); // List<Artifact>
+final found = all.where((a) => a.name == 'poem.txt').firstOrNull;
+
+// Create / replace artifacts:
+session.addArtifacts([
+  Artifact(name: 'notes.md', parts: [TextPart(text: '# Notes')]),
+]);
+```
+
+## Reading artifacts on the client
+
+The `remoteAgent` client tracks artifacts on `chat.artifacts`; each response
+exposes `res.artifacts`; and each streamed chunk exposes `chunk.artifact` as it
+arrives.
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/workspaceAgent');
+final chat = agent.chat();
+
+final turn = chat.sendTextStream('Create index.html and styles.css');
+await for (final chunk in turn.stream) {
+  final artifact = chunk.artifact;
+  if (artifact != null) {
+    // artifact.name, artifact.parts — render/store it live.
+  }
+}
+final res = await turn.response;
+print(res.artifacts); // artifacts produced this turn
+print(chat.artifacts); // all artifacts tracked for the session
+```
+
+> In [multi-agent orchestration](agents-multi-agent.md), the `agents()`
+> delegation middleware can merge sub-agent artifacts into the parent session
+> (namespaced by an invocation id) via its `artifactStrategy` option.

--- a/skills/developing-genkit-dart/references/agents-background.md
+++ b/skills/developing-genkit-dart/references/agents-background.md
@@ -1,0 +1,109 @@
+# Background Agents / Detaching
+
+> Detaching **requires a [session store](agents-sessions.md)** — the server
+> needs somewhere to write the result when background work finishes. Read
+> [agents.md](agents.md) first.
+
+Detaching runs a turn in the background: the server saves a `pending` snapshot
+and returns a `snapshotId` **immediately**, keeps processing, then updates the
+snapshot to a terminal status (`completed` / `failed` / `aborted` / `expired`).
+The client polls for completion and can abort.
+
+## Define the agent (store required)
+
+```dart
+import 'package:genkit/genkit.dart';
+
+import 'genkit.dart';
+
+final backgroundAgent = ai.defineAgent(
+  name: 'backgroundAgent',
+  system: 'You are a senior research analyst. Produce a comprehensive '
+      'markdown report.',
+  use: [retry()],
+  store: InMemorySessionStore(), // REQUIRED for detach
+);
+```
+
+Expose its companion actions so the client can poll/abort (see
+[agents.md](agents.md#serve-an-agent-over-http)):
+
+```dart
+import 'package:genkit_shelf/genkit_shelf.dart';
+
+router.post('/api/backgroundAgent', shelfHandler(backgroundAgent.action));
+router.post(
+  '/api/backgroundAgent/getSnapshot',
+  shelfHandler(backgroundAgent.getSnapshotDataAction),
+);
+router.post(
+  '/api/backgroundAgent/abort',
+  shelfHandler(backgroundAgent.abortAgentAction),
+);
+```
+
+## Client-side: detach + poll + abort
+
+On the client (`package:genkit/client.dart`), `chat.detachText(...)` (or
+`chat.detach(...)`) resolves immediately with a `DetachedTask` carrying the
+`snapshotId`. `task.poll(...)` yields snapshots until a terminal status;
+`task.abort()` cancels the background work.
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/backgroundAgent');
+
+// Submit — resolves immediately with a handle.
+final task = await agent.chat().detachText('Quantum computing impact');
+print(task.snapshotId);
+
+// Poll until a terminal status.
+await for (final snap in task.poll(interval: Duration(milliseconds: 1500))) {
+  final status = snap.status?.value ?? 'pending';
+  if (status == 'completed') {
+    final messages = snap.state?.messages ?? [];
+    final lastModel =
+        messages.where((m) => m.role == Role.model).lastOrNull;
+    final text =
+        (lastModel?.content ?? []).map((p) => p.text ?? '').join();
+    print(text);
+    break;
+  } else if (status == 'failed') {
+    throw Exception('Background task failed on the server.');
+  } else if (status == 'aborted' || status == 'expired') {
+    break;
+  }
+  // 'pending' → keep polling
+}
+
+// Abort an in-flight task at any time:
+await task.abort();
+```
+
+## Server-side: detach + wait
+
+You can also detach from a server-side chat and wait for the result. `task.wait`
+polls the store until a terminal state and resolves with the final snapshot.
+
+```dart
+final chat = backgroundAgent.chat();
+final task = await chat.detachText('Write a report on renewable energy trends');
+print(task.snapshotId); // available immediately
+
+final snapshot = await task.wait(interval: Duration(seconds: 2));
+print(snapshot?.status?.value); // 'completed' | 'failed' | 'aborted' | 'expired'
+```
+
+## Status values
+
+- `pending` — still processing.
+- `completed` — completed successfully (read the result from `snapshot.state.messages`).
+- `failed` — error during processing.
+- `aborted` — cancelled by the client via `abort()`.
+- `expired` — the background worker stopped responding (e.g. server restart);
+  terminal, the task can never complete.
+
+> Equivalent low-level wire protocol: the client sends `{ detach: true }` with
+> the message; `poll`/`wait` hit the agent's `getSnapshot` action, and `abort`
+> hits the `abort` action. `remoteAgent` wraps all of this for you.

--- a/skills/developing-genkit-dart/references/agents-background.md
+++ b/skills/developing-genkit-dart/references/agents-background.md
@@ -44,7 +44,7 @@ router.post(
 
 ## Client-side: detach + poll + abort
 
-On the client (`package:genkit/client.dart`), `chat.detachText(...)` (or
+On the client (`package:genkit/client.dart`), `chat.detach(text: ...)` (or
 `chat.detach(...)`) resolves immediately with a `DetachedTask` carrying the
 `snapshotId`. `task.poll(...)` yields `AgentSnapshot`s until a terminal status;
 `task.abort()` cancels the background work. Each `AgentSnapshot` surfaces
@@ -56,7 +56,7 @@ import 'package:genkit/client.dart';
 final agent = remoteAgent(url: '/api/backgroundAgent');
 
 // Submit — resolves immediately with a handle.
-final task = await agent.chat().detachText('Quantum computing impact');
+final task = await agent.chat().detach(text: 'Quantum computing impact');
 print(task.snapshotId);
 
 // Poll until a terminal status.
@@ -89,7 +89,7 @@ polls the store until a terminal state and resolves with the final snapshot.
 
 ```dart
 final chat = backgroundAgent.chat();
-final task = await chat.detachText('Write a report on renewable energy trends');
+final task = await chat.detach(text: 'Write a report on renewable energy trends');
 print(task.snapshotId); // available immediately
 
 final snapshot = await task.wait(interval: Duration(seconds: 2));

--- a/skills/developing-genkit-dart/references/agents-background.md
+++ b/skills/developing-genkit-dart/references/agents-background.md
@@ -46,8 +46,9 @@ router.post(
 
 On the client (`package:genkit/client.dart`), `chat.detachText(...)` (or
 `chat.detach(...)`) resolves immediately with a `DetachedTask` carrying the
-`snapshotId`. `task.poll(...)` yields snapshots until a terminal status;
-`task.abort()` cancels the background work.
+`snapshotId`. `task.poll(...)` yields `AgentSnapshot`s until a terminal status;
+`task.abort()` cancels the background work. Each `AgentSnapshot` surfaces
+`.status`, `.messages`, `.artifacts`, and typed `.custom` state directly.
 
 ```dart
 import 'package:genkit/client.dart';
@@ -62,7 +63,7 @@ print(task.snapshotId);
 await for (final snap in task.poll(interval: Duration(milliseconds: 1500))) {
   final status = snap.status?.value ?? 'pending';
   if (status == 'completed') {
-    final messages = snap.state?.messages ?? [];
+    final messages = snap.messages;
     final lastModel =
         messages.where((m) => m.role == Role.model).lastOrNull;
     final text =
@@ -98,7 +99,7 @@ print(snapshot?.status?.value); // 'completed' | 'failed' | 'aborted' | 'expired
 ## Status values
 
 - `pending` — still processing.
-- `completed` — completed successfully (read the result from `snapshot.state.messages`).
+- `completed` — completed successfully (read the result from `snapshot.messages`).
 - `failed` — error during processing.
 - `aborted` — cancelled by the client via `abort()`.
 - `expired` — the background worker stopped responding (e.g. server restart);

--- a/skills/developing-genkit-dart/references/agents-branching.md
+++ b/skills/developing-genkit-dart/references/agents-branching.md
@@ -77,13 +77,17 @@ starting a turn — handy for restoring a UI after a reload (e.g. a snapshotId
 stored in the URL). The server must expose the agent's `getSnapshotDataAction`
 (see [agents.md](agents.md#serve-an-agent-over-http)).
 
+`getSnapshot(...)` returns an `AgentSnapshot<State>` — a typed veneer that
+surfaces `.messages`, `.artifacts`, and typed `.custom` state directly (use
+`.sessionState` for the raw `SessionState` if you need it).
+
 ```dart
 import 'package:genkit/client.dart';
 
 final agent = remoteAgent(url: '/api/branchingAgent');
 
 final snapshot = await agent.getSnapshot(snapshotId: snapshotId);
-final history = (snapshot?.state?.messages ?? [])
+final history = (snapshot?.messages ?? [])
     .where((m) => m.role == Role.user || m.role == Role.model)
     .map((m) => (
           role: m.role.value,

--- a/skills/developing-genkit-dart/references/agents-branching.md
+++ b/skills/developing-genkit-dart/references/agents-branching.md
@@ -24,18 +24,18 @@ final assistant = ai.defineAgent(
 );
 
 final root = assistant.chat();
-final res1 = await root.sendText('Hello!');
+final res1 = await root.send(text: 'Hello!');
 final checkpoint = res1.snapshotId; // branch point
 
 // Branch A — forks from `checkpoint`.
 final branchA = assistant.chat(snapshotId: checkpoint);
-await branchA.sendText('My name is Bob.');
-final resA = await branchA.sendText('What is my name?'); // -> Bob
+await branchA.send(text: 'My name is Bob.');
+final resA = await branchA.send(text: 'What is my name?'); // -> Bob
 
 // Branch B — forks from the SAME `checkpoint`, fully independent.
 final branchB = assistant.chat(snapshotId: checkpoint);
-await branchB.sendText('My name is John.');
-final resB = await branchB.sendText('What is my name?'); // -> John
+await branchB.send(text: 'My name is John.');
+final resB = await branchB.send(text: 'What is my name?'); // -> John
 ```
 
 ## Client-side branching ("pick a variant")
@@ -56,8 +56,8 @@ Future<(AgentResponse, AgentResponse)> twoVariants(String text) async {
       snapshotId != null ? agent.chat(snapshotId: snapshotId) : agent.chat();
 
   final results = await Future.wait([
-    makeChat().sendText(text),
-    makeChat().sendText(text),
+    makeChat().send(text: text),
+    makeChat().send(text: text),
   ]);
   // results[0].snapshotId != results[1].snapshotId — both branch from the
   // same point.

--- a/skills/developing-genkit-dart/references/agents-branching.md
+++ b/skills/developing-genkit-dart/references/agents-branching.md
@@ -1,0 +1,96 @@
+# Agent Branching
+
+> Requires a [session store](agents-sessions.md) so snapshots are persistent.
+> Read [agents.md](agents.md) first.
+
+A `snapshotId` is an **immutable checkpoint**, like a git commit. You can fork as
+many independent timelines as you want from the same snapshot — each turn from a
+snapshot creates a new, independent snapshot; the original is unchanged.
+
+To branch, open a new `chat` attached to an earlier snapshot via
+`agent.chat(snapshotId: ...)`.
+
+## Server-side branching
+
+```dart
+import 'package:genkit/genkit.dart';
+
+import 'genkit.dart';
+
+final assistant = ai.defineAgent(
+  name: 'assistant',
+  system: 'You are a helpful assistant.',
+  store: InMemorySessionStore(),
+);
+
+final root = assistant.chat();
+final res1 = await root.sendText('Hello!');
+final checkpoint = res1.snapshotId; // branch point
+
+// Branch A — forks from `checkpoint`.
+final branchA = assistant.chat(snapshotId: checkpoint);
+await branchA.sendText('My name is Bob.');
+final resA = await branchA.sendText('What is my name?'); // -> Bob
+
+// Branch B — forks from the SAME `checkpoint`, fully independent.
+final branchB = assistant.chat(snapshotId: checkpoint);
+await branchB.sendText('My name is John.');
+final resB = await branchB.sendText('What is my name?'); // -> John
+```
+
+## Client-side branching ("pick a variant")
+
+A common pattern: generate two variants from the same checkpoint in parallel,
+let the user pick one, and continue from the chosen snapshot.
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/branchingAgent');
+String? snapshotId; // current branch point
+
+Future<(AgentResponse, AgentResponse)> twoVariants(String text) async {
+  // Each variant gets its own chat branching from the same snapshot
+  // (or a fresh session when there's no branch point yet).
+  AgentChat makeChat() =>
+      snapshotId != null ? agent.chat(snapshotId: snapshotId) : agent.chat();
+
+  final results = await Future.wait([
+    makeChat().sendText(text),
+    makeChat().sendText(text),
+  ]);
+  // results[0].snapshotId != results[1].snapshotId — both branch from the
+  // same point.
+  return (results[0], results[1]);
+}
+
+// When the user picks a variant, its snapshotId becomes the new branch point:
+void pick(String chosenSnapshotId) {
+  snapshotId = chosenSnapshotId;
+}
+```
+
+## Restoring history from a snapshot
+
+Use `agent.getSnapshot(snapshotId: ...)` to read a snapshot's state without
+starting a turn — handy for restoring a UI after a reload (e.g. a snapshotId
+stored in the URL). The server must expose the agent's `getSnapshotDataAction`
+(see [agents.md](agents.md#serve-an-agent-over-http)).
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/branchingAgent');
+
+final snapshot = await agent.getSnapshot(snapshotId: snapshotId);
+final history = (snapshot?.state?.messages ?? [])
+    .where((m) => m.role == Role.user || m.role == Role.model)
+    .map((m) => (
+          role: m.role.value,
+          text: m.content.map((p) => p.text ?? '').join(),
+        ))
+    .toList();
+```
+
+> Abandoned branches simply remain in the store as immutable snapshots; nothing
+> is overwritten when you branch.

--- a/skills/developing-genkit-dart/references/agents-custom.md
+++ b/skills/developing-genkit-dart/references/agents-custom.md
@@ -182,7 +182,7 @@ final chat = researchAgent.chat(
     artifacts: [],
   ),
 );
-final turn = chat.sendTextStream('Impacts of electric vehicles?');
+final turn = chat.sendStream(text: 'Impacts of electric vehicles?');
 await for (final chunk in turn.stream) {
   // chunk.text for model output; chunk.custom['status'] for live progress
 }

--- a/skills/developing-genkit-dart/references/agents-custom.md
+++ b/skills/developing-genkit-dart/references/agents-custom.md
@@ -45,6 +45,11 @@ Key `sess` methods:
   `sess.getMessages()` includes it. `input.message?.content` holds the parts.
 - `sess.getMessages()` — the full message history.
 - `sess.addMessages([...])` — append messages (e.g. your final model response).
+- `sess.updateCustom(mutator)` / `sess.getCustom()` — read and mutate typed
+  custom state directly on the runner (no `ai.currentSession()` needed). The
+  mutator is `(State? state) => State`; each call auto-emits a `customPatch`
+  chunk. Its typing follows `stateSchema` — with the map schema below the state
+  is `Map<String, dynamic>?`; with a generated `.$schema` it's your typed class.
 
 ## Example: multi-step research agent
 
@@ -54,23 +59,25 @@ import 'package:schemantic/schemantic.dart';
 
 import 'genkit.dart';
 
-Map<String, dynamic> _state(dynamic custom) {
-  if (custom is Map) return Map<String, dynamic>.from(custom);
-  return {'subQuestions': <dynamic>[], 'subAnswers': <dynamic>[]};
+Map<String, dynamic> _state(Map<String, dynamic>? custom) {
+  if (custom == null) {
+    return {'subQuestions': <dynamic>[], 'subAnswers': <dynamic>[]};
+  }
+  return custom;
 }
 
 final researchAgent = ai.defineCustomAgent(
   name: 'researchAgent',
+  stateSchema: .map(.string(), .dynamicSchema()),
   fn: (sess, options) async {
     Message? lastMessage;
-    final session = ai.currentSession()!;
 
     await sess.run((input, ctx) async {
       final userText = input.message?.content.firstOrNull?.text ?? '';
 
       // Step 1: decompose (a fast model). Mutating custom state auto-emits a
       // `customPatch` chunk so the client's tracked state stays live.
-      session.updateCustom((s) {
+      sess.updateCustom((s) {
         final state = _state(s);
         state['status'] = 'Decomposing question into sub-topics…';
         return state;
@@ -87,7 +94,7 @@ final researchAgent = ai.defineCustomAgent(
       final subQuestions =
           (decompose.output ?? [userText]).map((e) => e.toString()).toList();
 
-      session.updateCustom((s) {
+      sess.updateCustom((s) {
         final state = _state(s);
         state['subQuestions'] = subQuestions;
         state['subAnswers'] = <dynamic>[];
@@ -97,7 +104,7 @@ final researchAgent = ai.defineCustomAgent(
       // Step 2: research each sub-question (main model).
       final subAnswers = <Map<String, dynamic>>[];
       for (var i = 0; i < subQuestions.length; i++) {
-        session.updateCustom((s) {
+        sess.updateCustom((s) {
           final state = _state(s);
           state['status'] =
               'Researching (${i + 1}/${subQuestions.length})';
@@ -110,14 +117,14 @@ final researchAgent = ai.defineCustomAgent(
         );
         subAnswers.add({'question': subQuestions[i], 'answer': research.text});
       }
-      session.updateCustom((s) {
+      sess.updateCustom((s) {
         final state = _state(s);
         state['subAnswers'] = subAnswers;
         return state;
       });
 
       // Step 3: synthesize and STREAM the final answer to the client.
-      session.updateCustom((s) {
+      sess.updateCustom((s) {
         final state = _state(s);
         state['status'] = 'Synthesizing final response…';
         return state;
@@ -135,7 +142,7 @@ final researchAgent = ai.defineCustomAgent(
       lastMessage = finalResponse.message;
       if (lastMessage != null) sess.addMessages([lastMessage!]);
 
-      session.updateCustom((s) {
+      sess.updateCustom((s) {
         final state = _state(s);
         state['status'] = 'Done';
         return state;
@@ -157,7 +164,7 @@ final researchAgent = ai.defineCustomAgent(
 
 ## Custom status streaming
 
-Calling `session.updateCustom(...)` during the turn automatically emits a
+Calling `sess.updateCustom(...)` during the turn automatically emits a
 `customPatch` chunk, so the `remoteAgent` client's tracked
 [custom state](agents-state.md) (e.g. the `status` field) stays live
 **mid-stream** without any extra wiring. Stream model output separately with

--- a/skills/developing-genkit-dart/references/agents-custom.md
+++ b/skills/developing-genkit-dart/references/agents-custom.md
@@ -28,6 +28,7 @@ Agent<State> defineCustomAgent<State>({
   String? description,
   SchemanticType<State>? stateSchema,
   SessionStore? store,
+  ClientTransform? clientTransform,
   required AgentFn fn, // (SessionRunner sess, AgentFnOptions options) => Future<AgentResult>
 });
 ```
@@ -35,8 +36,9 @@ Agent<State> defineCustomAgent<State>({
 The handler receives a session runner `sess` and `AgentFnOptions options`
 (`options.sendChunk(...)` streams chunks to the client; `options.context` holds
 the ambient [per-turn context](agents.md#per-turn-ambient-context) — e.g. auth,
-derived server-side for remote agents). It must return an `AgentResult` with the
-final `message` for the turn.
+derived server-side for remote agents). It returns an `AgentResult`, typically
+carrying the final `message` for the turn (`AgentResult.message` is nullable —
+pass `message: null` when the turn produced no message).
 
 Key `sess` methods:
 

--- a/skills/developing-genkit-dart/references/agents-custom.md
+++ b/skills/developing-genkit-dart/references/agents-custom.md
@@ -1,0 +1,179 @@
+# Advanced Custom Agents — `defineCustomAgent`
+
+> `ai.defineCustomAgent` comes from `package:genkit/genkit.dart`. Read
+> [agents.md](agents.md) and [agent state](agents-state.md) first.
+
+`defineAgent` runs a single prompt + tool loop. When you need **full control of
+the turn** — multiple sequential model calls, custom logic between them, manual
+message/state management, or custom progress streaming — use
+`ai.defineCustomAgent`. You provide the handler that runs the turn.
+
+## When to use it
+
+Reach for `defineCustomAgent` when a turn needs to:
+
+- make **multiple model calls** with your own orchestration between them;
+- run **multi-step workflows** (decompose → research → synthesize);
+- **manually manage** messages and custom state;
+- **stream custom status** updates to the client mid-turn.
+
+Otherwise prefer `defineAgent` (simpler; custom state still works — see
+[agent state](agents-state.md)).
+
+## Signature
+
+```dart
+Agent<State> defineCustomAgent<State>({
+  required String name,
+  String? description,
+  SchemanticType<State>? stateSchema,
+  SessionStore? store,
+  required AgentFn fn, // (SessionRunner sess, AgentFnOptions options) => Future<AgentResult>
+});
+```
+
+The handler receives a session runner `sess` and `AgentFnOptions options`
+(`options.sendChunk(...)` streams chunks to the client). It must return an
+`AgentResult` with the final `message` for the turn.
+
+Key `sess` methods:
+
+- `sess.run((input, ctx) async {...})` — runs the turn; adds `input.message`
+  (the incoming user message) to the session before calling your callback, so
+  `sess.getMessages()` includes it. `input.message?.content` holds the parts.
+- `sess.getMessages()` — the full message history.
+- `sess.addMessages([...])` — append messages (e.g. your final model response).
+
+## Example: multi-step research agent
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+Map<String, dynamic> _state(dynamic custom) {
+  if (custom is Map) return Map<String, dynamic>.from(custom);
+  return {'subQuestions': <dynamic>[], 'subAnswers': <dynamic>[]};
+}
+
+final researchAgent = ai.defineCustomAgent(
+  name: 'researchAgent',
+  fn: (sess, options) async {
+    Message? lastMessage;
+    final session = ai.currentSession()!;
+
+    await sess.run((input, ctx) async {
+      final userText = input.message?.content.firstOrNull?.text ?? '';
+
+      // Step 1: decompose (a fast model). Mutating custom state auto-emits a
+      // `customPatch` chunk so the client's tracked state stays live.
+      session.updateCustom((s) {
+        final state = _state(s);
+        state['status'] = 'Decomposing question into sub-topics…';
+        return state;
+      });
+
+      final decompose = await ai.generate(
+        model: liteModel,
+        prompt: 'Break this into 2-3 sub-questions. Return ONLY a JSON array '
+            'of strings.\nUser question: "$userText"',
+        use: [retry()],
+        outputFormat: 'json',
+        outputSchema: SchemanticType.list(SchemanticType.string()),
+      );
+      final subQuestions =
+          (decompose.output ?? [userText]).map((e) => e.toString()).toList();
+
+      session.updateCustom((s) {
+        final state = _state(s);
+        state['subQuestions'] = subQuestions;
+        state['subAnswers'] = <dynamic>[];
+        return state;
+      });
+
+      // Step 2: research each sub-question (main model).
+      final subAnswers = <Map<String, dynamic>>[];
+      for (var i = 0; i < subQuestions.length; i++) {
+        session.updateCustom((s) {
+          final state = _state(s);
+          state['status'] =
+              'Researching (${i + 1}/${subQuestions.length})';
+          return state;
+        });
+        final research = await ai.generate(
+          use: [retry()],
+          prompt: 'Answer concisely in 2-3 paragraphs.\n\n'
+              'Question: ${subQuestions[i]}',
+        );
+        subAnswers.add({'question': subQuestions[i], 'answer': research.text});
+      }
+      session.updateCustom((s) {
+        final state = _state(s);
+        state['subAnswers'] = subAnswers;
+        return state;
+      });
+
+      // Step 3: synthesize and STREAM the final answer to the client.
+      session.updateCustom((s) {
+        final state = _state(s);
+        state['status'] = 'Synthesizing final response…';
+        return state;
+      });
+
+      final synthesis = ai.generateStream(
+        use: [retry()],
+        prompt: 'Synthesize a unified markdown answer to "$userText" from:\n'
+            '${subAnswers.map((a) => '${a['question']}: ${a['answer']}').join('\n\n')}',
+      );
+      await for (final chunk in synthesis) {
+        options.sendChunk(AgentStreamChunk(modelChunk: chunk.rawChunk));
+      }
+      final finalResponse = await synthesis.onResult;
+      lastMessage = finalResponse.message;
+      if (lastMessage != null) sess.addMessages([lastMessage!]);
+
+      session.updateCustom((s) {
+        final state = _state(s);
+        state['status'] = 'Done';
+        return state;
+      });
+
+      return null;
+    });
+
+    return AgentResult(
+      message: lastMessage ??
+          Message(
+            role: Role.model,
+            content: [TextPart(text: 'Research complete.')],
+          ),
+    );
+  },
+);
+```
+
+## Custom status streaming
+
+Calling `session.updateCustom(...)` during the turn automatically emits a
+`customPatch` chunk, so the `remoteAgent` client's tracked
+[custom state](agents-state.md) (e.g. the `status` field) stays live
+**mid-stream** without any extra wiring. Stream model output separately with
+`options.sendChunk(AgentStreamChunk(modelChunk: ...))`.
+
+Seed and run a custom agent exactly like a regular one:
+
+```dart
+final chat = researchAgent.chat(
+  state: SessionState(
+    custom: {'subQuestions': <dynamic>[], 'subAnswers': <dynamic>[]},
+    messages: [],
+    artifacts: [],
+  ),
+);
+final turn = chat.sendTextStream('Impacts of electric vehicles?');
+await for (final chunk in turn.stream) {
+  // chunk.text for model output; chunk.custom['status'] for live progress
+}
+await turn.response;
+```

--- a/skills/developing-genkit-dart/references/agents-custom.md
+++ b/skills/developing-genkit-dart/references/agents-custom.md
@@ -33,8 +33,10 @@ Agent<State> defineCustomAgent<State>({
 ```
 
 The handler receives a session runner `sess` and `AgentFnOptions options`
-(`options.sendChunk(...)` streams chunks to the client). It must return an
-`AgentResult` with the final `message` for the turn.
+(`options.sendChunk(...)` streams chunks to the client; `options.context` holds
+the ambient [per-turn context](agents.md#per-turn-ambient-context) — e.g. auth,
+derived server-side for remote agents). It must return an `AgentResult` with the
+final `message` for the turn.
 
 Key `sess` methods:
 

--- a/skills/developing-genkit-dart/references/agents-deployment.md
+++ b/skills/developing-genkit-dart/references/agents-deployment.md
@@ -1,0 +1,113 @@
+# Deploying / Serving Agents over HTTP
+
+> Uses `shelfHandler` from `package:genkit_shelf` and the agent's companion
+> actions. Read [agents.md](agents.md) first. For the general `genkit_shelf`
+> reference, see [genkit_shelf.md](genkit_shelf.md).
+
+An agent is served as HTTP endpoints. Each `Agent` exposes three actions:
+
+- `agent.action` → `POST /api/<name>` — the main turn action.
+- `agent.getSnapshotDataAction` → `POST /api/<name>/getSnapshot` — read a
+  snapshot's state. Needed for [snapshot restore](agents-branching.md) and
+  [background](agents-background.md) polling.
+- `agent.abortAgentAction` → `POST /api/<name>/abort` — cancel a
+  [background](agents-background.md) turn.
+
+These paths match the `remoteAgent` client defaults (`${url}/getSnapshot`,
+`${url}/abort`), so a client only needs the base `url`.
+
+## A reusable `mountAgent` helper
+
+When serving several agents, a small helper keeps registration consistent.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_shelf/genkit_shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+import 'package:agents_sample/weather_agent.dart';
+import 'package:agents_sample/background_agent.dart';
+
+/// Mounts an agent's turn action plus its `/getSnapshot` and `/abort` actions.
+void mountAgent(Router router, String path, Agent agent) {
+  router.post('/api/$path', shelfHandler(agent.action));
+  router.post('/api/$path/getSnapshot', shelfHandler(agent.getSnapshotDataAction));
+  router.post('/api/$path/abort', shelfHandler(agent.abortAgentAction));
+}
+
+final router = Router();
+mountAgent(router, 'weatherAgent', weatherAgent);
+mountAgent(router, 'backgroundAgent', backgroundAgent);
+
+// A client-managed (stateless) agent only needs the turn action:
+router.post(
+  '/api/weatherAgentStateless',
+  shelfHandler(weatherAgentStateless.action),
+);
+```
+
+Which companions to enable:
+
+| Agent capability | `getSnapshot` | `abort` |
+| --- | --- | --- |
+| Plain chat (client- or server-state) | – | – |
+| Snapshot restore / [branching](agents-branching.md) | ✓ | – |
+| [Background](agents-background.md) / detach | ✓ | ✓ |
+
+## CORS for browser clients
+
+A browser `remoteAgent` calling a different origin (e.g. a Jaspr/Flutter web dev
+server on another port) needs CORS. **Streaming requires the
+`X-Genkit-Stream-Id` header** to be allowed. Use `shelf_cors_headers`.
+
+```dart
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_cors_headers/shelf_cors_headers.dart';
+
+final handler = const Pipeline()
+    .addMiddleware(logRequests())
+    .addMiddleware(
+      corsHeaders(
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers':
+              'Content-Type, Accept, X-Genkit-Stream-Id',
+          'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        },
+      ),
+    )
+    .addHandler(router.call);
+
+final port = int.tryParse(Platform.environment['PORT'] ?? '') ?? 8080;
+final server = await io.serve(handler, InternetAddress.anyIPv4, port);
+print('Agents API server running on http://localhost:${server.port}');
+```
+
+## Exposing plain flows
+
+Agents are just actions, so you can serve ordinary flows the same way — e.g.
+helper endpoints used by a UI:
+
+```dart
+router.post('/api/workspace/files', shelfHandler(listWorkspaceFiles));
+router.post('/api/workspace/file', shelfHandler(readWorkspaceFile));
+```
+
+## Registering agents/flows
+
+Agents register with Genkit when their defining top-level `final` is evaluated.
+Importing the module (e.g. in your server's `bin/server.dart`) and referencing
+the agent — as `mountAgent(...)` does — ensures the `defineAgent` call runs.
+
+## Notes
+
+- The wire body matches the Genkit client: `{ "data": <input>, "init": <init> }`.
+- For persistence across restarts, use `FileSessionStore`
+  (`package:genkit/io.dart`) or `FirestoreSessionStore`
+  (`package:genkit_google_cloud`) instead of `InMemorySessionStore`. See
+  [sessions](agents-sessions.md).
+- Consuming these endpoints from Dart/Flutter/web uses `remoteAgent` from
+  `package:genkit/client.dart` — see [agents.md](agents.md#consume-an-agent-from-a-client-remoteagent).

--- a/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
@@ -19,7 +19,7 @@ resume on the same `chat` (or, for raw calls, carry the returned state/snapshot
 back into the resume).
 
 Flow: `chat.sendText(...)` → response has `res.interrupts` → collect human input
-→ `chat.resume(AgentResume(respond: [...]))`.
+→ `chat.resume(respond: [...])`.
 
 ## Define an interrupt (a tool that interrupts)
 
@@ -100,7 +100,7 @@ exposes:
   **not** send.
 
 Resume the **same** chat with `chat.resume(...)` / `chat.resumeStream(...)`,
-passing an `AgentResume`:
+passing `respond` / `restart` entries directly:
 
 ```dart
 final chat = bankingAgent.chat();
@@ -113,11 +113,9 @@ if (approval != null) {
 
   // Collect the human decision, then resume with the interrupt's output:
   res = await chat.resume(
-    AgentResume(
-      respond: [
-        approval.respond({'approved': true, 'feedback': 'Looks good'}),
-      ],
-    ),
+    respond: [
+      approval.respond({'approved': true, 'feedback': 'Looks good'}),
+    ],
   );
 }
 print(res.text); // final confirmation
@@ -127,7 +125,7 @@ Streaming variant:
 
 ```dart
 final turn = chat.resumeStream(
-  AgentResume(respond: [approval.respond({'approved': true})]),
+  respond: [approval.respond({'approved': true})],
 );
 await for (final chunk in turn.stream) {
   stdout.write(chunk.text);
@@ -140,10 +138,8 @@ You can resume multiple interrupts at once by passing several builders, and mix
 
 ```dart
 await chat.resume(
-  AgentResume(
-    respond: [a.respond({'approved': true})],
-    restart: [b.restart()],
-  ),
+  respond: [a.respond({'approved': true})],
+  restart: [b.restart()],
 );
 ```
 
@@ -169,9 +165,7 @@ if (pending != null) {
 
   // 2. After the human approves/denies, resume the SAME chat.
   final turn = chat.resumeStream(
-    AgentResume(
-      respond: [pending.respond({'approved': true, 'feedback': 'ok'})],
-    ),
+    respond: [pending.respond({'approved': true, 'feedback': 'ok'})],
   );
   await for (final chunk in turn.stream) {
     /* render chunk.text */
@@ -195,9 +189,7 @@ middleware reads:
 // `interrupt` is the paused AgentInterrupt from `res.interrupts`.
 // Pass this restart entry back when resuming the chat:
 await chat.resume(
-  AgentResume(
-    restart: [interrupt.restart({'tool-approved': true})],
-  ),
+  restart: [interrupt.restart({'tool-approved': true})],
 );
 ```
 

--- a/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
@@ -18,7 +18,7 @@ agent uses a [session store](agents-sessions.md) or
 resume on the same `chat` (or, for raw calls, carry the returned state/snapshot
 back into the resume).
 
-Flow: `chat.sendText(...)` → response has `res.interrupts` → collect human input
+Flow: `chat.send(text: ...)` → response has `res.interrupts` → collect human input
 → `chat.resume(respond: [...])`.
 
 ## Define an interrupt (a tool that interrupts)
@@ -104,7 +104,7 @@ passing `respond` / `restart` entries directly:
 
 ```dart
 final chat = bankingAgent.chat();
-var res = await chat.sendText('Transfer \$500 to my savings account.');
+var res = await chat.send(text: 'Transfer \$500 to my savings account.');
 
 final approval =
     res.interrupts.where((i) => i.name == 'userApproval').firstOrNull;
@@ -156,7 +156,7 @@ final agent = remoteAgent(url: '/api/bankingAgent');
 final chat = agent.chat();
 
 // 1. Send and detect the pause.
-final res = await chat.sendText('Transfer \$500 to savings.');
+final res = await chat.send(text: 'Transfer \$500 to savings.');
 final pending =
     res.interrupts.where((i) => i.name == 'userApproval').firstOrNull;
 

--- a/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
@@ -94,8 +94,10 @@ exposes:
 - `.input` — the data the model passed in.
 - `.respond(output)` — **builder** returning a resume entry that supplies the
   tool's output (without executing it). Does **not** send.
-- `.restart()` — **builder** re-issuing the original tool request (retry / let
-  the tool actually run). Does **not** send.
+- `.restart([payload])` — **builder** re-issuing the original tool request (retry
+  / let the tool actually run). Pass an optional `Map` payload; it is nested
+  under `metadata.resumed` and read back tool-side via `ctx.resumed`. Does
+  **not** send.
 
 Resume the **same** chat with `chat.resume(...)` / `chat.resumeStream(...)`,
 passing an `AgentResume`:
@@ -184,24 +186,28 @@ if (pending != null) {
 The [`toolApproval`](genkit_middleware.md) middleware turns selected tools into
 approval interrupts without any custom interrupt code. The middleware gates each
 tool call itself: a tool is allowed to run only if it is in the `approved` list
-or its request carries top-level metadata `{ 'tool-approved': true }`. To let an
-approved tool through on resume, re-issue the paused `ToolRequestPart` with that
-metadata added:
+or its `resumed` payload carries `{ 'tool-approved': true }`. To let an approved
+tool through on resume, **restart** the paused interrupt with that payload — the
+`.restart(...)` builder nests it under `metadata.resumed`, exactly what the
+middleware reads:
 
 ```dart
-final approved = ToolRequestPart(
-  toolRequest: interrupt.toolRequest,
-  metadata: {...?interrupt.metadata, 'tool-approved': true},
+// `interrupt` is the paused AgentInterrupt from `res.interrupts`.
+// Pass this restart entry back when resuming the chat:
+await chat.resume(
+  AgentResume(
+    restart: [interrupt.restart({'tool-approved': true})],
+  ),
 );
-// Pass `approved` back as the restart entry when resuming.
 ```
 
 If instead you write your own `ctx.interrupt(...)` gate inside a tool (as in the
-`coding_agent` sample), you inspect the resume payload yourself:
+`coding_agent` sample), you inspect the resume payload yourself via the
+`ctx.resumed` getter:
 
 ```dart
-final resumed = ctx.toolRequest?.metadata?['resumed'];
-final isApproved = resumed is Map && resumed['toolApproved'] == true;
+final resumed = ctx.resumed; // the payload passed to `.restart(...)`
+final isApproved = resumed is Map && resumed['tool-approved'] == true;
 ```
 
 ## Notes & gotchas

--- a/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
@@ -1,0 +1,221 @@
+# Agent Human-in-the-Loop / Interrupts
+
+> Read [agents.md](agents.md) first.
+
+An **interrupt** pauses an agent mid-turn and hands control back to your code (or
+a human) — e.g. to approve a sensitive action, collect missing input, or confirm
+a plan. Internally it's a **tool call used as control flow**: the interrupt tool
+never runs to completion on the server; it pauses the turn. You then **resume**
+from the exact point it paused.
+
+> **Dart has no `defineInterrupt`.** Model an interrupt as a normal tool whose
+> body calls `ctx.interrupt(...)`. Because the tool never returns a value, omit
+> `outputSchema` — the output is supplied by the caller on resume.
+
+Interrupts are **orthogonal to persistence** — they work the same whether the
+agent uses a [session store](agents-sessions.md) or
+[client-managed state](agents.md#client-managed-state-no-server-store). Just
+resume on the same `chat` (or, for raw calls, carry the returned state/snapshot
+back into the resume).
+
+Flow: `chat.sendText(...)` → response has `res.interrupts` → collect human input
+→ `chat.resume(AgentResume(respond: [...]))`.
+
+## Define an interrupt (a tool that interrupts)
+
+Define it like a tool and add it to the agent's `tools`. `ctx.interrupt(...)`
+pauses the turn; its argument is the data shown to the human.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+part 'banking_agent.g.dart';
+
+@Schema()
+abstract class $UserApprovalInput {
+  @Field(description: 'The action to be approved')
+  String get action;
+  @Field(description: 'Details about the action')
+  String get details;
+}
+
+@Schema()
+abstract class $TransferMoneyInput {
+  double get amount;
+  String get toAccount;
+}
+
+@Schema()
+abstract class $TransferMoneyOutput {
+  bool get success;
+  String get transactionId;
+}
+
+/// Interrupt: always pauses. The caller provides `{ approved, feedback }` on
+/// resume. No `outputSchema` — the output comes from the resume call.
+final userApproval = ai.defineTool(
+  name: 'userApproval',
+  description: 'Ask the user for approval before a sensitive action.',
+  inputSchema: UserApprovalInput.$schema,
+  fn: (input, ctx) async => ctx.interrupt(),
+);
+
+/// Executes the transfer. Only reached after the user approves.
+final transferMoney = ai.defineTool(
+  name: 'transferMoney',
+  description: 'Transfer money to a specified account.',
+  inputSchema: TransferMoneyInput.$schema,
+  outputSchema: TransferMoneyOutput.$schema,
+  fn: (input, _) async => TransferMoneyOutput(
+    success: true,
+    transactionId: 'txn-${DateTime.now().millisecondsSinceEpoch}',
+  ),
+);
+
+final bankingAgent = ai.defineAgent(
+  name: 'bankingAgent',
+  system: 'You are a banking assistant. ALWAYS use the userApproval interrupt '
+      'to confirm before executing transferMoney.',
+  tools: [userApproval, transferMoney],
+  use: [retry()],
+  store: InMemorySessionStore(),
+);
+```
+
+## Detect and resume (server-side)
+
+`res.interrupts` is non-empty when the agent paused. Each `AgentInterrupt`
+exposes:
+
+- `.name` — the interrupt's name.
+- `.input` — the data the model passed in.
+- `.respond(output)` — **builder** returning a resume entry that supplies the
+  tool's output (without executing it). Does **not** send.
+- `.restart()` — **builder** re-issuing the original tool request (retry / let
+  the tool actually run). Does **not** send.
+
+Resume the **same** chat with `chat.resume(...)` / `chat.resumeStream(...)`,
+passing an `AgentResume`:
+
+```dart
+final chat = bankingAgent.chat();
+var res = await chat.sendText('Transfer \$500 to my savings account.');
+
+final approval =
+    res.interrupts.where((i) => i.name == 'userApproval').firstOrNull;
+if (approval != null) {
+  print(approval.input); // { action, details } — show this to the human
+
+  // Collect the human decision, then resume with the interrupt's output:
+  res = await chat.resume(
+    AgentResume(
+      respond: [
+        approval.respond({'approved': true, 'feedback': 'Looks good'}),
+      ],
+    ),
+  );
+}
+print(res.text); // final confirmation
+```
+
+Streaming variant:
+
+```dart
+final turn = chat.resumeStream(
+  AgentResume(respond: [approval.respond({'approved': true})]),
+);
+await for (final chunk in turn.stream) {
+  stdout.write(chunk.text);
+}
+final res = await turn.response;
+```
+
+You can resume multiple interrupts at once by passing several builders, and mix
+`respond` (supply output) with `restart` (re-run the tool):
+
+```dart
+await chat.resume(
+  AgentResume(
+    respond: [a.respond({'approved': true})],
+    restart: [b.restart()],
+  ),
+);
+```
+
+## Client-side (browser) interrupts
+
+The same pattern works over HTTP with `remoteAgent` from
+`package:genkit/client.dart`. The client tracks the snapshot, so resuming the
+same `chat` continues exactly where it paused.
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/bankingAgent');
+final chat = agent.chat();
+
+// 1. Send and detect the pause.
+final res = await chat.sendText('Transfer \$500 to savings.');
+final pending =
+    res.interrupts.where((i) => i.name == 'userApproval').firstOrNull;
+
+if (pending != null) {
+  // pending.input → { action, details }; render an approval dialog.
+
+  // 2. After the human approves/denies, resume the SAME chat.
+  final turn = chat.resumeStream(
+    AgentResume(
+      respond: [pending.respond({'approved': true, 'feedback': 'ok'})],
+    ),
+  );
+  await for (final chunk in turn.stream) {
+    /* render chunk.text */
+  }
+  final finalRes = await turn.response;
+  // If finalRes.interrupts is non-empty, the agent paused again — repeat.
+}
+```
+
+## Interrupts with tool-approval middleware
+
+The [`toolApproval`](genkit_middleware.md) middleware turns selected tools into
+approval interrupts without any custom interrupt code. The middleware gates each
+tool call itself: a tool is allowed to run only if it is in the `approved` list
+or its request carries top-level metadata `{ 'tool-approved': true }`. To let an
+approved tool through on resume, re-issue the paused `ToolRequestPart` with that
+metadata added:
+
+```dart
+final approved = ToolRequestPart(
+  toolRequest: interrupt.toolRequest,
+  metadata: {...?interrupt.metadata, 'tool-approved': true},
+);
+// Pass `approved` back as the restart entry when resuming.
+```
+
+If instead you write your own `ctx.interrupt(...)` gate inside a tool (as in the
+`coding_agent` sample), you inspect the resume payload yourself:
+
+```dart
+final resumed = ctx.toolRequest?.metadata?['resumed'];
+final isApproved = resumed is Map && resumed['toolApproved'] == true;
+```
+
+## Notes & gotchas
+
+- **No store required.** Interrupts work with either a
+  [session store](agents-sessions.md) or
+  [client-managed state](agents.md#client-managed-state-no-server-store).
+- **`respond`/`restart` are builders.** They return resume entries; they do not
+  send. You still call `chat.resume(...)`.
+- **Resume validation.** The server validates each `respond`/`restart` entry
+  against the conversation history — always build entries from the interrupt
+  objects in the response, not hand-rolled parts.
+- **Re-pausing.** After resuming, the new response may interrupt again; loop
+  until `res.interrupts` is empty.
+- **UX tip:** don't render a model message bubble for an interrupted turn; show
+  the approval UI from `interrupt.input` instead, then render the model's reply
+  after resuming.

--- a/skills/developing-genkit-dart/references/agents-multi-agent.md
+++ b/skills/developing-genkit-dart/references/agents-multi-agent.md
@@ -79,8 +79,8 @@ Run it like any other agent:
 
 ```dart
 final chat = orchestratorAgent.chat();
-final turn = chat.sendTextStream(
-  'Research the best sorting algorithms, then write a Dart quicksort.',
+final turn = chat.sendStream(
+  text: 'Research the best sorting algorithms, then write a Dart quicksort.',
 );
 await for (final chunk in turn.stream) {
   stdout.write(chunk.text);

--- a/skills/developing-genkit-dart/references/agents-multi-agent.md
+++ b/skills/developing-genkit-dart/references/agents-multi-agent.md
@@ -1,0 +1,123 @@
+# Multi-Agent Orchestration / Sub-Agents
+
+> Sub-agent delegation uses the `agents()` middleware from
+> `package:genkit_middleware/agents.dart`. Read [agents.md](agents.md) first.
+
+A common pattern is an **orchestrator** agent that delegates tasks to
+specialized **sub-agents** (e.g. a `researcher` and a `coder`). The `agents()`
+middleware injects one delegation tool per sub-agent (`delegate_to_<name>`),
+appends a `<sub-agents>` block to the orchestrator's system prompt, and — when
+the model calls a delegation tool — runs the sub-agent and returns its response
+as the tool result.
+
+To make the middleware available, register `AgentsPlugin()` on the `Genkit`
+instance:
+
+```dart
+import 'package:genkit_middleware/agents.dart';
+
+final ai = Genkit(plugins: [googleAI(), AgentsPlugin(), RetryPlugin()]);
+```
+
+## 1. Define the sub-agents
+
+Give each sub-agent a `description` — it's auto-discovered from registry metadata
+and shown to the orchestrator so the model knows when to delegate.
+
+```dart
+import 'genkit.dart';
+
+final researcher = ai.defineAgent(
+  name: 'researcher',
+  description:
+      'A thorough research assistant that provides well-sourced answers.',
+  system: 'You are a thorough research assistant. When asked a question, '
+      'provide a clear, well-structured, and well-sourced answer.',
+  maxTurns: 10,
+);
+
+final coder = ai.defineAgent(
+  name: 'coder',
+  description: 'Writes, debugs, and explains code. Use for any programming tasks.',
+  system: 'You are an expert programmer. Provide clean, well-commented code '
+      'with explanations. Use Dart by default unless asked otherwise.',
+  maxTurns: 10,
+);
+```
+
+## 2. Wire up the orchestrator
+
+Add `agents()` to the orchestrator's `use: [...]`. Pass the sub-agent **names**;
+their descriptions are auto-discovered from the registry.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_middleware/agents.dart';
+
+import 'genkit.dart';
+
+final orchestratorAgent = ai.defineAgent(
+  name: 'orchestratorAgent',
+  system: '''
+You are a helpful project assistant.
+
+Analyze the user's request and delegate to the appropriate sub-agent.
+If the request requires both research AND code, call them sequentially.
+After receiving sub-agent responses, synthesize a final answer for the user.''',
+  use: [
+    agents(
+      agents: ['researcher', 'coder'],
+      maxDelegations: 5, // guard rail against runaway delegation loops
+      historyLength: 4, // forward the last N user/model messages as context
+    ),
+  ],
+  store: InMemorySessionStore(),
+);
+```
+
+Run it like any other agent:
+
+```dart
+final chat = orchestratorAgent.chat();
+final turn = chat.sendTextStream(
+  'Research the best sorting algorithms, then write a Dart quicksort.',
+);
+await for (final chunk in turn.stream) {
+  stdout.write(chunk.text);
+}
+final res = await turn.response;
+```
+
+## `agents()` options
+
+- `agents` (required): `List<String>` of sub-agent names. Each description is
+  auto-discovered from the registry.
+- `toolPrefix`: prefix for generated tool names. Defaults to `delegate_to` →
+  `delegate_to_<agent>`.
+- `maxDelegations`: max delegations per `generate` call. Prevents runaway loops.
+- `historyLength`: number of recent user/model messages forwarded to sub-agents
+  as context. `0`/omitted sends only the task description.
+- `artifactStrategy`: `'inline'` (default) or `'session'` — see below.
+
+## Sharing artifacts between agents
+
+Sub-agents can produce [artifacts](agents-artifacts.md). `artifactStrategy`
+controls how they reach the orchestrator:
+
+- `'inline'` (default): artifact content is included in the delegation tool
+  result (so the model sees it directly) **and** merged into the parent session.
+- `'session'`: artifacts are merged into the parent session only; the tool result
+  lists artifact names, not content. Merged artifacts are namespaced by an
+  invocation id (`<invocationId>/<name>`).
+
+## Other middleware
+
+`package:genkit_middleware` also exports `filesystem`, `skills`, and
+`toolApproval`; `retry` ships in core `package:genkit`. They attach the same way
+via `use: [...]` on an agent (or on `ai.generate`) — see
+[using middleware](genkit_middleware.md). `retry()` is commonly paired with
+delegation.
+
+> Note: if a sub-agent triggers an [interrupt](agents-human-in-the-loop.md), it
+> is reported back to the orchestrator as a normal tool response (not propagated
+> as a resumable interrupt). Delegate self-contained tasks.

--- a/skills/developing-genkit-dart/references/agents-sessions.md
+++ b/skills/developing-genkit-dart/references/agents-sessions.md
@@ -44,8 +44,8 @@ automatically:
 
 ```dart
 final chat = logbookAgent.chat();
-final res1 = await chat.sendText('Log this: I started studying Genkit today.');
-final res2 = await chat.sendText('What did I study today?'); // remembers turn 1
+final res1 = await chat.send(text: 'Log this: I started studying Genkit today.');
+final res2 = await chat.send(text: 'What did I study today?'); // remembers turn 1
 print('${res1.snapshotId} ${res2.snapshotId}');
 ```
 
@@ -54,7 +54,7 @@ Resume a prior conversation by snapshot id (server-side):
 ```dart
 // Continue an existing session from a snapshot, restoring its history.
 final resumed = await logbookAgent.loadChat(snapshotId: res2.snapshotId);
-await resumed.sendText('Add another note.');
+await resumed.send(text: 'Add another note.');
 ```
 
 `agent.chat(snapshotId: ...)` opens a new chat that **branches** from a snapshot

--- a/skills/developing-genkit-dart/references/agents-sessions.md
+++ b/skills/developing-genkit-dart/references/agents-sessions.md
@@ -1,0 +1,182 @@
+# Agent Sessions & Persistence
+
+> `InMemorySessionStore` and `Session`/`SessionStore`
+> come from `package:genkit/genkit.dart`; `FileSessionStore` from
+> `package:genkit/io.dart` (needs `dart:io`); `FirestoreSessionStore` from
+> `package:genkit_google_cloud`. See [agents.md](agents.md) for the basics first.
+
+When an agent has a `store`, the **server** owns the session history. Each turn
+produces an immutable **snapshot**; the snapshot chain is what carries
+conversation state forward. A store also enables [branching](agents-branching.md)
+and [background execution](agents-background.md). (Interrupts work with or without
+a store — see [human-in-the-loop](agents-human-in-the-loop.md).)
+
+## Pick a store
+
+```dart
+import 'package:genkit/genkit.dart'; // InMemorySessionStore
+import 'package:genkit/io.dart'; // FileSessionStore (dart:io)
+
+// In-memory: great for tests/dev; lost on restart.
+final memStore = InMemorySessionStore();
+
+// File-backed: snapshots persisted as JSON under <dir>/global/.
+final fileStore = FileSessionStore('./.snapshots');
+
+// File store with chain pruning — keep only the last N snapshots in a chain.
+final pruning = FileSessionStore('./.snapshots', maxPersistedChainLength: 3);
+```
+
+Attach it to the agent:
+
+```dart
+import 'genkit.dart';
+
+final logbookAgent = ai.defineAgent(
+  name: 'logbookAgent',
+  system: 'You are a personal logbook assistant.',
+  store: fileStore,
+);
+```
+
+A single `chat` persists to the store and threads the snapshot forward
+automatically:
+
+```dart
+final chat = logbookAgent.chat();
+final res1 = await chat.sendText('Log this: I started studying Genkit today.');
+final res2 = await chat.sendText('What did I study today?'); // remembers turn 1
+print('${res1.snapshotId} ${res2.snapshotId}');
+```
+
+Resume a prior conversation by snapshot id (server-side):
+
+```dart
+// Continue an existing session from a snapshot, restoring its history.
+final resumed = await logbookAgent.loadChat(snapshotId: res2.snapshotId);
+await resumed.sendText('Add another note.');
+```
+
+`agent.chat(snapshotId: ...)` opens a new chat that **branches** from a snapshot
+without pre-loading its history; `agent.loadChat(...)` returns a chat with the
+history restored. See [branching](agents-branching.md).
+
+## Typed session state
+
+Use `stateSchema` to attach typed custom state to the session. It is validated
+when a snapshot is loaded. Seed initial custom state when opening the chat via
+the `state` argument (a `SessionState`, whose `custom` field holds your data).
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+part 'profile_agent.g.dart';
+
+@Schema()
+abstract class $Profile {
+  String get name;
+  String get tier; // 'free' | 'pro'
+}
+
+final profileAgent = ai.defineAgent(
+  name: 'profileAgent',
+  system: 'Greet the user by name and tailor answers to their tier.',
+  stateSchema: Profile.$schema,
+  store: InMemorySessionStore(),
+);
+
+// Custom state lives under `.custom` of the SessionState.
+final chat = profileAgent.chat(
+  state: SessionState(
+    custom: {'name': 'Ada', 'tier': 'pro'},
+    messages: [],
+    artifacts: [],
+  ),
+);
+```
+
+See [working with state](agents-state.md) for reading/mutating custom state
+inside tools and syncing it to the client.
+
+## Interrupts (human-in-the-loop)
+
+Interrupts pause a turn so a human can approve/provide input, then resume from
+the exact pause point. They work with a store or with client-managed state
+(persistence is orthogonal). See the dedicated reference:
+[Human-in-the-loop / interrupts](agents-human-in-the-loop.md).
+
+## Firestore session store (scalable)
+
+
+For production, `FirestoreSessionStore` (from `package:genkit_google_cloud`)
+persists each turn as an incremental JSON Patch diff anchored to periodic sharded
+checkpoints — no single document approaches Firestore's 1 MiB limit, and
+reads/writes per turn are bounded by `checkpointInterval` rather than total
+session length (scales to long-lived chat/coding agents).
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_cloud/firestore_session_store.dart';
+
+import 'genkit.dart';
+
+final myAgent = ai.defineAgent(
+  name: 'myAgent',
+  system: 'You are a helpful assistant.',
+  // Defaults to a new Firestore() using Application Default Credentials.
+  store: FirestoreSessionStore(),
+);
+```
+
+Options:
+
+- `db`: explicit `Firestore` instance (defaults to a new `Firestore()`, honoring
+  `FIRESTORE_EMULATOR_HOST`).
+- `collection`: snapshot collection (default `'genkit-sessions'`). Companion
+  collections `'<collection>-pointers'` and `'<collection>-shards'` are derived.
+- `checkpointInterval`: turns between full-state checkpoints (default `25`).
+  Lower for small, read-heavy state; raise for large per-turn state.
+- `shardSize`: max bytes per shard/diff document (default `512 KiB`).
+- `snapshotPathPrefix`: `String Function(Map<String, dynamic>? context)?` — a
+  per-tenant prefix derived from the call context (defaults to `'global'`).
+
+## Implementing a custom `SessionStore`
+
+Implement the `SessionStore` interface. `getSnapshot` loads by `snapshotId` OR
+`sessionId`; `saveSnapshot` atomically reads → mutates → persists. Optionally
+implement `SnapshotChangeNotifier.onSnapshotStateChange` (used by background
+agents) to subscribe to snapshot status changes.
+
+```dart
+import 'package:genkit/genkit.dart';
+
+class MySessionStore implements SessionStore {
+  @override
+  Future<SessionSnapshot?> getSnapshot({
+    String? snapshotId,
+    String? sessionId,
+    Map<String, dynamic>? context,
+  }) async {
+    // Load and return a snapshot, or null.
+    return null;
+  }
+
+  @override
+  Future<String?> saveSnapshot(
+    String? snapshotId,
+    SnapshotMutator mutator, {
+    Map<String, dynamic>? context,
+  }) async {
+    // Read → mutate → persist; return the snapshotId used, or null when the
+    // mutator returns null.
+    return snapshotId;
+  }
+}
+```
+
+> Check the exact `SessionStore` method signatures in your installed version with
+> `dart doc` or by inspecting `package:genkit` — the shape above matches the
+> in-memory and file stores.

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -48,10 +48,11 @@ final taskAgent = ai.defineAgent(
 
 ## Read & mutate state inside tools
 
-Tools call `ai.currentSession()` to access the live session, then
-`session.getCustom()` / `session.updateCustom(mutator)`. `updateCustom` takes
-`(dynamic custom) => dynamic` and returns the new state. Each call auto-emits a
-`customPatch` chunk to the client.
+Tools call `ai.currentSession<State>()` to access the live, **typed** session,
+then `session.getCustom()` / `session.updateCustom(mutator)`. `updateCustom` is
+fully typed: the mutator is `(State? state) => State` — it receives the current
+typed state (`null` before it's first set) and returns the new state. Each call
+auto-emits a `customPatch` chunk to the client.
 
 ```dart
 @Schema()
@@ -60,14 +61,10 @@ abstract class $AddTaskInput {
   String get title;
 }
 
-Map<String, dynamic> _stateOrEmpty(dynamic custom) {
-  if (custom is Map) {
-    final map = Map<String, dynamic>.from(custom);
-    map['tasks'] = (map['tasks'] as List?)?.toList() ?? <dynamic>[];
-    map['nextId'] = map['nextId'] ?? 1;
-    return map;
-  }
-  return {'tasks': <dynamic>[], 'nextId': 1};
+@Schema()
+abstract class $ToggleTaskInput {
+  @Field(description: 'The task ID to toggle')
+  int get id;
 }
 
 final addTask = ai.defineTool(
@@ -76,22 +73,65 @@ final addTask = ai.defineTool(
   inputSchema: AddTaskInput.$schema,
   outputSchema: TaskItem.$schema,
   fn: (input, _) async {
-    final session = ai.currentSession()!;
-    late Map<String, dynamic> newTask;
-    session.updateCustom((custom) {
-      final s = _stateOrEmpty(custom);
-      newTask = {'id': s['nextId'], 'title': input.title, 'done': false};
-      (s['tasks'] as List).add(newTask);
-      s['nextId'] = (s['nextId'] as int) + 1;
-      return s;
+    final session = ai.currentSession<TaskState>()!;
+    late TaskItem newTask;
+    session.updateCustom((state) {
+      state ??= TaskState(tasks: [], nextId: 1);
+      newTask = TaskItem(id: state.nextId, title: input.title, done: false);
+      state.tasks = [...state.tasks, newTask];
+      state.nextId += 1;
+      return state;
     });
-    return TaskItem.fromJson(newTask);
+    return newTask;
   },
 );
 ```
 
-`ai.currentSession()` returns `null` when called outside an active session (e.g.
-a tool invoked without a running agent turn), so only use it inside agent tools.
+Because the state is typed, you work with the generated `TaskState` / `TaskItem`
+classes directly — no manual `Map` munging or `fromJson`. Assign back to the
+setters (e.g. `state.tasks = [...]`) so the mutated values are written to the
+session.
+
+`ai.currentSession<State>()` returns `null` when called outside an active session
+(e.g. a tool invoked without a running agent turn), so only use it inside agent
+tools.
+
+For tools that look up and mutate an existing item, a small shared helper keeps
+the not-found handling in one place:
+
+```dart
+Map<String, dynamic> _mutateTaskById(
+  int id,
+  Map<String, dynamic> Function(List<TaskItem> tasks, int idx) onFound,
+) {
+  final session = ai.currentSession<TaskState>()!;
+  var result = <String, dynamic>{'success': false};
+  session.updateCustom((state) {
+    state ??= TaskState(tasks: [], nextId: 1);
+    final tasks = state.tasks;
+    final idx = tasks.indexWhere((t) => t.id == id);
+    if (idx >= 0) {
+      result = onFound(tasks, idx);
+      // Reassign so the mutated list is written back to the session state.
+      state.tasks = tasks;
+    } else {
+      result = {'success': false, 'error': 'Task $id not found'};
+    }
+    return state;
+  });
+  return result;
+}
+
+final toggleTask = ai.defineTool(
+  name: 'toggleTask',
+  description: 'Toggle a task done/undone by its ID.',
+  inputSchema: ToggleTaskInput.$schema,
+  fn: (input, _) async => _mutateTaskById(input.id, (tasks, idx) {
+    tasks[idx].done = !tasks[idx].done;
+    return {'success': true, 'task': tasks[idx].toJson()};
+  }),
+);
+```
 
 ## Seed and read state (server-side)
 

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -1,0 +1,152 @@
+# Working with Agent State
+
+> Read [agents.md](agents.md) first.
+
+Beyond message history, an agent session can hold typed **custom state** — your
+own structured data (a task list, a workflow status, counters, etc.). Tools read
+and mutate it during a turn, and it is automatically synced to the
+[`remoteAgent`](agents.md#consume-an-agent-from-a-client-remoteagent) client via
+`customPatch` chunks (so the client's tracked state stays live mid-stream).
+
+## Declare the state shape
+
+Pass a `stateSchema` (a schemantic `.$schema`) to `defineAgent`. It's validated
+when a snapshot is loaded.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+part 'task_agent.g.dart';
+
+@Schema()
+abstract class $TaskItem {
+  int get id;
+  String get title;
+  bool get done;
+}
+
+@Schema()
+abstract class $TaskState {
+  List<$TaskItem> get tasks;
+  int get nextId;
+}
+
+final taskAgent = ai.defineAgent(
+  name: 'taskAgent',
+  stateSchema: TaskState.$schema,
+  system: "You manage the user's task list. Use the tools to modify it.",
+  tools: [addTask /*, toggleTask, removeTask */],
+  use: [retry()],
+);
+```
+
+`stateSchema` works with the standard `defineAgent` — you do **not** need
+`defineCustomAgent` for custom state.
+
+## Read & mutate state inside tools
+
+Tools call `ai.currentSession()` to access the live session, then
+`session.getCustom()` / `session.updateCustom(mutator)`. `updateCustom` takes
+`(dynamic custom) => dynamic` and returns the new state. Each call auto-emits a
+`customPatch` chunk to the client.
+
+```dart
+@Schema()
+abstract class $AddTaskInput {
+  @Field(description: 'Short description of the task')
+  String get title;
+}
+
+Map<String, dynamic> _stateOrEmpty(dynamic custom) {
+  if (custom is Map) {
+    final map = Map<String, dynamic>.from(custom);
+    map['tasks'] = (map['tasks'] as List?)?.toList() ?? <dynamic>[];
+    map['nextId'] = map['nextId'] ?? 1;
+    return map;
+  }
+  return {'tasks': <dynamic>[], 'nextId': 1};
+}
+
+final addTask = ai.defineTool(
+  name: 'addTask',
+  description: 'Add a new task. Returns the created task.',
+  inputSchema: AddTaskInput.$schema,
+  outputSchema: TaskItem.$schema,
+  fn: (input, _) async {
+    final session = ai.currentSession()!;
+    late Map<String, dynamic> newTask;
+    session.updateCustom((custom) {
+      final s = _stateOrEmpty(custom);
+      newTask = {'id': s['nextId'], 'title': input.title, 'done': false};
+      (s['tasks'] as List).add(newTask);
+      s['nextId'] = (s['nextId'] as int) + 1;
+      return s;
+    });
+    return TaskItem.fromJson(newTask);
+  },
+);
+```
+
+`ai.currentSession()` returns `null` when called outside an active session (e.g.
+a tool invoked without a running agent turn), so only use it inside agent tools.
+
+## Seed and read state (server-side)
+
+Seed initial custom state when opening a chat. The `state` argument is a
+`SessionState`: custom data goes under `.custom` (alongside `messages` and
+`artifacts`).
+
+```dart
+final chat = taskAgent.chat(
+  state: SessionState(
+    custom: {'tasks': <dynamic>[], 'nextId': 1},
+    messages: [],
+    artifacts: [],
+  ),
+);
+
+final res = await chat.sendText('Add a task: buy groceries');
+print(res.state); // res.state returns the custom state directly
+```
+
+## Auto-sync to the `remoteAgent` client
+
+When you talk to the agent over HTTP, the `remoteAgent` client tracks custom
+state for you. Seed it the same way (`state.custom`), read live updates off each
+streamed chunk (`chunk.custom`), and read the authoritative state off
+`chat.state` after the turn completes.
+
+```dart
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '/api/taskAgent');
+final chat = agent.chat(
+  state: SessionState(
+    custom: {'tasks': <dynamic>[], 'nextId': 1},
+    messages: [],
+    artifacts: [],
+  ),
+);
+
+final turn = chat.sendTextStream('Add buy groceries, then mark it done');
+await for (final chunk in turn.stream) {
+  // Live custom state arrives via customPatch chunks:
+  if (chunk.custom != null) {
+    // e.g. render (chunk.custom as Map)['tasks']
+  }
+  // chunk.text for model output
+}
+final res = await turn.response;
+
+// Authoritative state after the turn:
+print(res.state);
+print(chat.state);
+```
+
+State updates ride on the streamed chunks — there is no `onStateChange`
+subscription. For live mid-stream status updates from a multi-step custom agent,
+see [advanced custom agents](agents-custom.md), which emit `customPatch` chunks as
+state changes.

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -148,7 +148,7 @@ final chat = taskAgent.chat(
   ),
 );
 
-final res = await chat.sendText('Add a task: buy groceries');
+final res = await chat.send(text: 'Add a task: buy groceries');
 print(res.state); // res.state returns the custom state directly
 ```
 
@@ -177,7 +177,7 @@ final chat = agent.chat(
   ),
 );
 
-final turn = chat.sendTextStream('Add buy groceries, then mark it done');
+final turn = chat.sendStream(text: 'Add buy groceries, then mark it done');
 await for (final chunk in turn.stream) {
   // Live custom state arrives via customPatch chunks:
   if (chunk.custom != null) {

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -112,6 +112,12 @@ final res = await chat.sendText('Add a task: buy groceries');
 print(res.state); // res.state returns the custom state directly
 ```
 
+> **Typed state.** When you supply a `stateSchema`, `res.state` / `chat.state`
+> (and `snapshot.custom`) are **parsed into the typed `State` object** (here a
+> `TaskState`), not a raw `Map`. `Agent`/`AgentChat`/`AgentResponse` are generic
+> over `State`, so the type flows through automatically. Without a `stateSchema`,
+> `state` is an untyped view over the JSON.
+
 ## Auto-sync to the `remoteAgent` client
 
 When you talk to the agent over HTTP, the `remoteAgent` client tracks custom

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -181,6 +181,27 @@ await for (final chunk in turn.stream) {
 final finalRes = await turn.response;
 ```
 
+### Per-turn ambient context
+
+`send`, `sendText`, `sendStream`, `sendTextStream`, `detach`, and `detachText`
+all accept an optional `context` map — ambient per-turn data (auth, request
+metadata, etc.) that tools can read via `getContext()` (and custom agents via
+`options.context`).
+
+```dart
+final res = await chat.sendText(
+  'What can I do?',
+  context: {
+    'auth': {'name': 'Ada', 'tier': 'pro'},
+  },
+);
+```
+
+> **In-process only.** The in-process transport honors `context`. The
+> **`remoteAgent` (HTTP) transport rejects a non-empty `context` with
+> `UnsupportedError`** — remote agents derive context server-side from the HTTP
+> request (headers/auth), so don't pass it from the client.
+
 ## Serve an agent over HTTP
 
 Use `shelfHandler` from `package:genkit_shelf`. Expose the main turn action, plus

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -185,7 +185,7 @@ final finalRes = await turn.response;
 
 `send`, `sendText`, `sendStream`, `sendTextStream`, `detach`, and `detachText`
 all accept an optional `context` map — ambient per-turn data (auth, request
-metadata, etc.) that tools can read via `getContext()` (and custom agents via
+metadata, etc.) that tools can read via `ctx.context` (and custom agents via
 `options.context`).
 
 ```dart

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -1,0 +1,279 @@
+# Agents
+
+> Server APIs come from `package:genkit/genkit.dart`; the browser/HTTP client
+> comes from `package:genkit/client.dart`.
+
+An **agent** is a persistent, multi-turn conversation primitive built on top of
+prompts + tools. Compared to a bare `ai.generate`/`ai.definePrompt` loop, an
+agent adds:
+
+- **Sessions**: multi-turn history tracked as immutable **snapshots**.
+- **State**: typed session state (messages + custom data + artifacts).
+- **Interrupts**: human-in-the-loop pause/resume.
+- **Branching**: fork a conversation from any snapshot.
+- **Detaching**: run a turn in the background and poll for the result.
+
+Progressive disclosure — read the file for the level you need:
+
+- This file: defining an agent, serving it, and **client-managed state** (no store).
+- [Sessions & persistence](agents-sessions.md): `SessionStore`, `InMemorySessionStore`, `FileSessionStore`, `FirestoreSessionStore`.
+- [Human-in-the-loop / interrupts](agents-human-in-the-loop.md): pausing for approval/input and resuming.
+- [Branching](agents-branching.md): forking a conversation from a snapshot.
+- [Background agents](agents-background.md): detaching long-running turns and polling.
+- [Working with state](agents-state.md): typed custom session state and client auto-sync.
+- [Artifacts](agents-artifacts.md): producing/reading named deliverables.
+- [Multi-agent orchestration](agents-multi-agent.md): delegating to sub-agents.
+- [Advanced custom agents](agents-custom.md): `defineCustomAgent` for full turn control.
+- [Deploying agents](agents-deployment.md): serving multiple agents over HTTP with `genkit_shelf`, CORS, other frameworks.
+
+## Setup
+
+Register the plugins your agents need on a shared `Genkit` instance. `retry` and
+`RetryPlugin` ship with the core `package:genkit/genkit.dart`; the other agentic
+middleware (`agents`, `filesystem`, `skills`, `toolApproval`) come from
+`package:genkit_middleware`.
+
+```dart
+// genkit.dart — shared instance + model refs.
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+
+/// The default (capable) model used by most agents.
+final ModelRef defaultModel = googleAI.gemini('gemini-flash-latest');
+
+/// A fast/cheap model for auxiliary tasks.
+final ModelRef liteModel = googleAI.gemini('gemini-flash-lite-latest');
+
+final Genkit ai = Genkit(
+  plugins: [
+    googleAI(),
+    RetryPlugin(),
+  ],
+  model: defaultModel,
+);
+```
+
+## Define an agent
+
+`ai.defineAgent` combines prompt + tool config + (optional) session store into a
+single registered action.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:schemantic/schemantic.dart';
+
+import 'genkit.dart';
+
+part 'weather_agent.g.dart';
+
+@Schema()
+abstract class $GetWeatherInput {
+  String get location;
+}
+
+@Schema()
+abstract class $GetWeatherOutput {
+  String get weather;
+  String get temperature;
+}
+
+final getWeather = ai.defineTool(
+  name: 'getWeather',
+  description: 'Get the current weather for a given location.',
+  inputSchema: GetWeatherInput.$schema,
+  outputSchema: GetWeatherOutput.$schema,
+  fn: (input, _) async => GetWeatherOutput(
+    weather: 'Sunny in ${input.location}',
+    temperature: '71F',
+  ),
+);
+
+final weatherAgent = ai.defineAgent(
+  name: 'weatherAgent',
+  system: 'You are a helpful weather assistant. Use the getWeather tool. '
+      'Be concise.',
+  tools: [getWeather],
+  use: [retry()],
+  store: InMemorySessionStore(),
+);
+```
+
+Common `defineAgent` options:
+
+- `name` (required): action name.
+- `description`: shown to an orchestrator that delegates to this agent (see
+  [multi-agent](agents-multi-agent.md)).
+- `system` / `prompt`: the prompt template (same as `definePrompt`).
+- `tools`: tools and interrupt-tools available to the agent.
+- `model`: override the default model (e.g. `model: liteModel`).
+- `use`: middleware layered on the turn (`retry()`, `filesystem(...)`, etc.).
+- `store`: a `SessionStore` for server-side persistence. See [sessions](agents-sessions.md).
+- `stateSchema`: a `SchemanticType<State>` describing custom session state.
+- `maxTurns`: cap the tool-calling loop (e.g. `maxTurns: 30`).
+
+> Schemas use the **schemantic** library (`@Schema()`, `.$schema`, `$`-prefixed
+> abstract classes with a generated `.g.dart` part). See
+> [references/schemantic.md](schemantic.md).
+
+## Agents and middleware go hand in hand
+
+Agents and [middleware](genkit_middleware.md) are built for each other: the
+`use: [...]` array is where you layer in sophisticated behavior without writing
+it yourself — sub-agent delegation, filesystem access, skill loading, tool
+approval, retries — each is one line.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_middleware/filesystem.dart';
+import 'package:genkit_middleware/skills.dart';
+import 'package:genkit_middleware/tool_approval.dart';
+
+import 'genkit.dart';
+
+final codingAgent = ai.defineAgent(
+  name: 'codingAgent',
+  system: 'You are an expert AI coding assistant working in a sandboxed '
+      'workspace.',
+  tools: [runShell, askUser], // your own custom tools/interrupts
+  use: [
+    // Require user approval (interrupt) before risky tools; reads/run auto-approved.
+    // Order matters: keep toolApproval before filesystem.
+    toolApproval(
+      approved: ['list_files', 'read_file', 'use_skill', 'run_shell', 'ask_user'],
+    ),
+    // list_files / read_file / write_file / search_and_replace, sandboxed.
+    filesystem(rootDirectory: workspaceDir),
+    // Load coding conventions on demand via a use_skill tool.
+    skills(skillPaths: [skillsDir]),
+    // Automatic retry on transient model errors.
+    retry(),
+  ],
+  store: InMemorySessionStore(), // needed for tool approval
+  maxTurns: 30,
+);
+```
+
+Register the corresponding plugins (`FilesystemPlugin()`, `SkillsPlugin()`,
+`ToolApprovalPlugin()`, and `RetryPlugin()`) on the `Genkit` instance so the
+`use: [...]` refs resolve at runtime. See [using middleware](genkit_middleware.md).
+
+## Chat with an agent (server-side)
+
+`agent.chat()` opens a conversation. A single `chat` carries state forward
+automatically across turns.
+
+```dart
+final chat = weatherAgent.chat();
+
+// Non-streaming turn:
+final res = await chat.sendText('Weather in Tokyo?');
+print(res.text);
+print(res.snapshotId); // immutable checkpoint id for this turn
+
+// Follow-up turn — history is carried automatically:
+final res2 = await chat.sendText('What about Paris?');
+
+// Streaming turn:
+final turn = chat.sendTextStream('And London?');
+await for (final chunk in turn.stream) {
+  stdout.write(chunk.text);
+}
+final finalRes = await turn.response;
+```
+
+## Serve an agent over HTTP
+
+Use `shelfHandler` from `package:genkit_shelf`. Expose the main turn action, plus
+the companion `getSnapshotDataAction` (state lookup/restore) and
+`abortAgentAction` (background aborts) where needed.
+
+```dart
+import 'package:genkit_shelf/genkit_shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+final router = Router();
+
+// Main turn endpoint:
+router.post('/api/weatherAgent', shelfHandler(weatherAgent.action));
+
+// Optional companions (snapshot restore / branching / background):
+router.post(
+  '/api/weatherAgent/getSnapshot',
+  shelfHandler(weatherAgent.getSnapshotDataAction),
+);
+router.post(
+  '/api/weatherAgent/abort',
+  shelfHandler(weatherAgent.abortAgentAction),
+);
+```
+
+For serving multiple agents, CORS/streaming headers for browser clients, and a
+full server, see [Deploying agents](agents-deployment.md).
+
+## Consume an agent from a client (`remoteAgent`)
+
+The browser/Dart client lives in `package:genkit/client.dart`. `remoteAgent`
+returns a typed HTTP client; `getSnapshotUrl`/`abortUrl` default to
+`${url}/getSnapshot` and `${url}/abort`.
+
+```dart
+import 'package:genkit/client.dart';
+
+final weather = remoteAgent(url: 'http://localhost:8080/api/weatherAgent');
+
+final chat = weather.chat();
+final turn = chat.sendTextStream('Weather in Tokyo?');
+await for (final chunk in turn.stream) {
+  stdout.write(chunk.text);
+}
+final res = await turn.response;
+print('${res.snapshotId} ${chat.snapshotId} ${chat.state}');
+
+// Multi-turn — the client carries state forward automatically:
+await chat.sendText('What about Paris?');
+
+// Errors surface as AgentError with an HTTP-ish status:
+try {
+  await remoteAgent(url: '$base/api/nope').chat().sendText('hi');
+} catch (err) {
+  if (err is AgentError) print(err.status);
+}
+```
+
+## Client-managed state (no server store)
+
+If the agent has **no `store`**, the server is fully stateless and the session
+state blob (messages + custom + artifacts) is owned by the caller. The
+`remoteAgent` client tracks it and round-trips it on every turn automatically —
+no `SessionStore`, no snapshot ids to manage.
+
+```dart
+// Server: no `store` → stateless. Client owns the state blob.
+final weatherAgentStateless = ai.defineAgent(
+  name: 'weatherAgentStateless',
+  system: 'You are a helpful weather assistant. Use the getWeather tool. '
+      'Be concise.',
+  tools: [getWeather],
+  use: [retry()],
+);
+```
+
+```dart
+// Client: reuse one `chat` and the state threads automatically.
+import 'package:genkit/client.dart';
+
+final agent = remoteAgent(url: '$base/api/weatherAgentStateless');
+final chat = agent.chat();
+
+await chat.sendText('Weather in London?');
+await chat.sendText('Is it sunny in Tokyo?'); // remembers prior turns
+
+// The tracked state is available after each turn:
+print(chat.state);
+print(chat.messages.length);
+```
+
+Use client-managed state when you don't want to run server-side storage. Use a
+[session store](agents-sessions.md) when the server should own history, or when
+you need branching or background execution.
+([Interrupts](agents-human-in-the-loop.md) work either way.)

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -216,6 +216,11 @@ The browser/Dart client lives in `package:genkit/client.dart`. `remoteAgent`
 returns a typed HTTP client; `getSnapshotUrl`/`abortUrl` default to
 `${url}/getSnapshot` and `${url}/abort`.
 
+`remoteAgent` talks to any Genkit agent endpoint over HTTP, so the **backend is
+fully interchangeable** — the agent can be implemented in Dart, JS/TypeScript, or
+Go. The wire protocol is the same; point `url` at whatever server hosts the
+agent.
+
 ```dart
 import 'package:genkit/client.dart';
 
@@ -239,6 +244,81 @@ try {
   if (err is AgentError) print(err.status);
 }
 ```
+
+## Using from Flutter
+
+There is nothing Flutter-specific about the client: a Flutter app uses the same
+`remoteAgent` from `package:genkit/client.dart` as any other Dart program. Two
+things matter in a real app — **auth headers** and **lifecycle**.
+
+Pass `headers` to attach per-request auth (e.g. a Firebase/OAuth bearer token).
+It's a `FutureOr<Map<String, String>?> Function()`, so it can be async and is
+called on every request:
+
+```dart
+final agent = remoteAgent(
+  url: 'https://your-backend.example.com/api/weatherAgent',
+  headers: () async => {
+    'Authorization': 'Bearer ${await getIdToken()}',
+  },
+);
+```
+
+Create the agent once (e.g. in `initState`, or a provider/singleton) and
+`close()` it when done to release the underlying HTTP client. To own the client
+yourself, pass `httpClient:` — then it stays caller-owned and `close()` leaves it
+open.
+
+A minimal streaming chat widget — pump `turn.stream` into the UI with
+`setState`, then await `turn.response`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:genkit/client.dart';
+
+class ChatView extends StatefulWidget {
+  const ChatView({super.key});
+  @override
+  State<ChatView> createState() => _ChatViewState();
+}
+
+class _ChatViewState extends State<ChatView> {
+  late final AgentApi _agent = remoteAgent(
+    url: 'http://localhost:8080/api/weatherAgent',
+  );
+  late final _chat = _agent.chat();
+  var _reply = '';
+
+  @override
+  void dispose() {
+    _agent.close(); // release the HTTP client
+    super.dispose();
+  }
+
+  Future<void> _send(String text) async {
+    setState(() => _reply = '');
+    final turn = _chat.sendTextStream(text);
+    await for (final chunk in turn.stream) {
+      setState(() => _reply += chunk.text); // append tokens live
+    }
+    await turn.response; // final AgentResponse (state already tracked on _chat)
+  }
+
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      Expanded(child: SingleChildScrollView(child: Text(_reply))),
+      TextField(onSubmitted: _send),
+    ],
+  );
+}
+```
+
+The `_chat` instance carries conversation state forward automatically across
+turns (`_chat.state`, `_chat.messages`, `_chat.snapshotId`), exactly as on the
+server. [Interrupts](agents-human-in-the-loop.md),
+[custom state](agents-state.md), and [artifacts](agents-artifacts.md) all work
+the same way from Flutter.
 
 ## Client-managed state (no server store)
 

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -166,15 +166,15 @@ automatically across turns.
 final chat = weatherAgent.chat();
 
 // Non-streaming turn:
-final res = await chat.sendText('Weather in Tokyo?');
+final res = await chat.send(text: 'Weather in Tokyo?');
 print(res.text);
 print(res.snapshotId); // immutable checkpoint id for this turn
 
 // Follow-up turn — history is carried automatically:
-final res2 = await chat.sendText('What about Paris?');
+final res2 = await chat.send(text: 'What about Paris?');
 
 // Streaming turn:
-final turn = chat.sendTextStream('And London?');
+final turn = chat.sendStream(text: 'And London?');
 await for (final chunk in turn.stream) {
   stdout.write(chunk.text);
 }
@@ -183,14 +183,13 @@ final finalRes = await turn.response;
 
 ### Per-turn ambient context
 
-`send`, `sendText`, `sendStream`, `sendTextStream`, `detach`, and `detachText`
-all accept an optional `context` map — ambient per-turn data (auth, request
-metadata, etc.) that tools can read via `ctx.context` (and custom agents via
-`options.context`).
+`send`, `sendStream`, and `detach` all accept an optional `context` map —
+ambient per-turn data (auth, request metadata, etc.) that tools can read via
+`ctx.context` (and custom agents via `options.context`).
 
 ```dart
-final res = await chat.sendText(
-  'What can I do?',
+final res = await chat.send(
+  text: 'What can I do?',
   context: {
     'auth': {'name': 'Ada', 'tier': 'pro'},
   },
@@ -248,7 +247,7 @@ import 'package:genkit/client.dart';
 final weather = remoteAgent(url: 'http://localhost:8080/api/weatherAgent');
 
 final chat = weather.chat();
-final turn = chat.sendTextStream('Weather in Tokyo?');
+final turn = chat.sendStream(text: 'Weather in Tokyo?');
 await for (final chunk in turn.stream) {
   stdout.write(chunk.text);
 }
@@ -256,11 +255,11 @@ final res = await turn.response;
 print('${res.snapshotId} ${chat.snapshotId} ${chat.state}');
 
 // Multi-turn — the client carries state forward automatically:
-await chat.sendText('What about Paris?');
+await chat.send(text: 'What about Paris?');
 
 // Errors surface as AgentError with an HTTP-ish status:
 try {
-  await remoteAgent(url: '$base/api/nope').chat().sendText('hi');
+  await remoteAgent(url: '$base/api/nope').chat().send(text: 'hi');
 } catch (err) {
   if (err is AgentError) print(err.status);
 }
@@ -318,7 +317,7 @@ class _ChatViewState extends State<ChatView> {
 
   Future<void> _send(String text) async {
     setState(() => _reply = '');
-    final turn = _chat.sendTextStream(text);
+    final turn = _chat.sendStream(text: text);
     await for (final chunk in turn.stream) {
       setState(() => _reply += chunk.text); // append tokens live
     }
@@ -366,8 +365,8 @@ import 'package:genkit/client.dart';
 final agent = remoteAgent(url: '$base/api/weatherAgentStateless');
 final chat = agent.chat();
 
-await chat.sendText('Weather in London?');
-await chat.sendText('Is it sunny in Tokyo?'); // remembers prior turns
+await chat.send(text: 'Weather in London?');
+await chat.send(text: 'Is it sunny in Tokyo?'); // remembers prior turns
 
 // The tracked state is available after each turn:
 print(chat.state);

--- a/skills/developing-genkit-dart/references/dotprompt.md
+++ b/skills/developing-genkit-dart/references/dotprompt.md
@@ -1,0 +1,205 @@
+# Dotprompt (.prompt files) — Genkit Dart
+
+## What it is
+
+`.prompt` files combine YAML frontmatter (model, config, schemas, tools,
+middleware) with a Handlebars template. They keep prompt logic out of Dart code
+and make variants and iteration easy.
+
+## Where files live
+
+By default Genkit loads `.prompt` files from `./prompts`. Configure with the
+`promptDir` parameter on `Genkit(...)` (set to `null` to disable auto-loading):
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+
+final ai = Genkit(
+  plugins: [googleAI()],
+  promptDir: './prompts', // default
+);
+```
+
+## File format
+
+`prompts/greeting.prompt`:
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    name: string
+    style: string
+---
+{{role "system"}}
+You are a {{style}} greeter.
+
+{{role "user"}}
+Greet {{name}}.
+```
+
+Schema fields use Picoschema (the compact form above) or you can reference a
+named schema registered with `defineSchema`. The `type, description` form is
+supported too, e.g. `name: string, the person to greet`.
+
+## Loading and calling a prompt
+
+`ai.prompt(name, {variant})` returns a `Future<ExecutablePrompt>`. The resolved
+`ExecutablePrompt` is a **callable object** — invoke it like a function. The
+input is a **positional** argument (there is no `input:` named parameter).
+
+```dart
+// Non-streaming
+final greetingPrompt = await ai.prompt('greeting');
+final response = await greetingPrompt({
+  'name': 'World',
+  'style': 'cheerful',
+});
+print(response.text);
+```
+
+### Streaming
+
+```dart
+final storyPrompt = await ai.prompt('story');
+final stream = storyPrompt.stream({'subject': 'a robot'});
+await for (final chunk in stream) {
+  print(chunk.text);
+}
+```
+
+### Render without generating
+
+Returns `GenerateActionOptions` (messages, model, config) without calling the
+model — useful for building `ai.generate` calls or evals:
+
+```dart
+final greetingPrompt = await ai.prompt('greeting');
+final rendered = await greetingPrompt.render({'name': 'World', 'style': 'casual'});
+rendered.model;    // resolved model
+rendered.messages; // rendered messages
+```
+
+## Registering named schemas
+
+Reference a schema by name in `.prompt` frontmatter (`input.schema` /
+`output.schema`) after registering it with `defineSchema` (a JSON Schema map):
+
+```dart
+ai.defineSchema('Recipe', {
+  'type': 'object',
+  'properties': {
+    'title': {'type': 'string'},
+    'steps': {'type': 'array', 'items': {'type': 'string'}},
+  },
+  'required': ['title', 'steps'],
+});
+```
+
+Then in `recipe.prompt`:
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    food: string
+output:
+  schema: Recipe
+  format: json
+---
+Generate a recipe for {{food}}.
+```
+
+For code-defined prompts (`ai.definePrompt`) you typically pass a
+[schemantic](schemantic.md)-generated schema (e.g. `JokeInput.schema`) as
+`inputSchema`.
+
+## Variants
+
+Name the file `<name>.<variant>.prompt` — e.g. `greeting.formal.prompt`. Load
+with the `variant` argument:
+
+```dart
+final formalPrompt = await ai.prompt('greeting', variant: 'formal');
+final response = await formalPrompt({'name': 'Dr. Smith', 'title': 'Professor'});
+```
+
+## Partials
+
+Reusable template fragments. Name a partial file `_<name>.prompt` and include it
+with `{{> name param=value}}`.
+
+`prompts/_signature.prompt` referenced from another template:
+```
+Write a short email to {{recipient}} about {{subject}}.
+
+{{> signature}}
+```
+
+## Tools, tool-loop control, and middleware
+
+`.prompt` frontmatter can configure tool calling and attach middleware, so an
+agent-style prompt is fully described in the file. This is based on
+`prompts/tripPlanner.prompt` from the agents testapp (with
+`returnToolRequests` shown for completeness):
+
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    tone: string
+tools:
+  - getAttractions
+  - getFlightInfo
+maxTurns: 20              # max tool-call loop iterations
+returnToolRequests: false # return tool requests instead of running them
+use:
+  - name: retry           # bare string also works: `- retry`
+    config:
+      maxRetries: 4
+---
+{{role "system"}}
+You are a friendly trip planning assistant. Help users plan trips by suggesting
+attractions and looking up flight information. Use the available tools to provide
+accurate, up-to-date information. Keep your tone {{tone}}.
+
+{{history}}
+```
+
+- `tools`: list of registered tool names.
+- `toolChoice`, `maxTurns`, `returnToolRequests`: same semantics as the
+  equivalent `ai.generate` options.
+- `use`: list of middleware refs. Each entry is a bare string (middleware name)
+  or a map with `name` and optional `config`. Names resolve against middleware
+  registered on the Genkit instance — register the middleware plugin so the name
+  is available:
+
+```dart
+final ai = Genkit(
+  plugins: [
+    googleAI(),
+    RetryPlugin(), // registers the `retry` middleware
+  ],
+  promptDir: './prompts',
+);
+```
+
+See [genkit_middleware](genkit_middleware.md) for the middleware package.
+
+## Backing an agent with a .prompt file
+
+`definePromptAgent` wires an agent directly to a `.prompt` file by name. The
+frontmatter (`tools`, `maxTurns`, `use`, ...) applies to the agent, and
+`promptInput` supplies template variables:
+
+```dart
+final tripPlannerAgent = ai.definePromptAgent(
+  promptName: 'tripPlanner',            // -> prompts/tripPlanner.prompt
+  promptInput: {'tone': 'enthusiastic'}, // fills {{tone}}
+  store: InMemorySessionStore(),
+);
+```
+
+See [Agents](agents.md) for defining and serving agents.

--- a/skills/developing-genkit-dart/references/genkit_middleware.md
+++ b/skills/developing-genkit-dart/references/genkit_middleware.md
@@ -87,6 +87,6 @@ if (response.finishReason == FinishReason.interrupted) {
 
 > **Agent-side resume.** When resuming an agent chat rather than a raw
 > `ai.generate` call, the interrupts are `AgentInterrupt`s; pass the same
-> `.restart(...)` builder in an `AgentResume`:
-> `chat.resume(AgentResume(restart: [interrupt.restart({'tool-approved': true})]))`.
+> `.restart(...)` builder directly to `chat.resume`:
+> `chat.resume(restart: [interrupt.restart({'tool-approved': true})])`.
 > See [human-in-the-loop](agents-human-in-the-loop.md).

--- a/skills/developing-genkit-dart/references/genkit_middleware.md
+++ b/skills/developing-genkit-dart/references/genkit_middleware.md
@@ -50,6 +50,12 @@ final response = await ai.generate(
 ## Tool Approval Middleware
 Intercepts tool execution for specified tools and requires explicit approval. Returns `FinishReason.interrupted`.
 
+A tool is allowed through only if it is in the `approved` list or its request's
+`resumed` payload carries `{ 'tool-approved': true }`. To approve on resume,
+re-issue the paused `ToolRequestPart` with `.restart({'tool-approved': true})` —
+the builder nests the payload under `metadata.resumed`, exactly what the
+middleware reads.
+
 ```dart
 final response = await ai.generate(
   prompt: 'Delete the database.',
@@ -60,8 +66,9 @@ final response = await ai.generate(
 );
 
 if (response.finishReason == FinishReason.interrupted) {
+  // `response.interrupts` is a List<ToolRequestPart>.
   final interrupt = response.interrupts.first;
-  
+
   // Ask user for approval
   final isApproved = await askUser();
 
@@ -70,15 +77,16 @@ if (response.finishReason == FinishReason.interrupted) {
       messages: response.messages, // Pass history
       toolChoice: ToolChoice.none, // Prevent immediate re-call
       interruptRestart: [
-        ToolRequestPart(
-          toolRequest: interrupt.toolRequest,
-          metadata: {
-            ...?interrupt.metadata, 
-            'tool-approved': true 
-          }, 
-        ),
+        // `.restart(...)` nests the payload under `metadata.resumed`.
+        interrupt.restart({'tool-approved': true}),
       ],
     );
   }
 }
 ```
+
+> **Agent-side resume.** When resuming an agent chat rather than a raw
+> `ai.generate` call, the interrupts are `AgentInterrupt`s; pass the same
+> `.restart(...)` builder in an `AgentResume`:
+> `chat.resume(AgentResume(restart: [interrupt.restart({'tool-approved': true})]))`.
+> See [human-in-the-loop](agents-human-in-the-loop.md).

--- a/skills/developing-genkit-go/references/prompts.md
+++ b/skills/developing-genkit-go/references/prompts.md
@@ -211,6 +211,63 @@ Write an article about {{topic}}.
 {{#if style}}Write in a {{style}} style.{{/if}}
 ```
 
+**Tools, tool-loop control, and middleware:**
+
+`.prompt` frontmatter can also configure tool calling and attach middleware, so
+an agent-style prompt can be fully described in the file:
+
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    tone: string
+tools:
+  - getAttractions
+  - getFlightInfo
+toolChoice: auto          # auto | required | none
+maxTurns: 20              # max tool-call loop iterations (WithMaxTurns)
+returnToolRequests: false # return tool requests instead of running them (WithReturnToolRequests)
+use:
+  - name: genkit-middleware/retry
+    config:
+      maxRetries: 2
+  - genkit-middleware/fallback   # bare string = middleware name, no config
+---
+{{role "system"}}
+You are a friendly trip planning assistant. Keep your tone {{tone}}.
+
+{{history}}
+```
+
+Field mapping:
+
+| Frontmatter | Option | Notes |
+| --- | --- | --- |
+| `tools` | `WithTools` | list of registered tool names (strings) |
+| `toolChoice` | `WithToolChoice` | `auto`, `required`, or `none` |
+| `maxTurns` | `WithMaxTurns` | integer |
+| `returnToolRequests` | `WithReturnToolRequests` | boolean |
+| `use` | `WithUse` | list of middleware refs |
+
+`use` entries are resolved by name against middleware registered on the `*Genkit`
+instance. Each entry is either a bare string (the middleware name) or a map with
+`name` and optional `config`. Register the built-in middleware plugin so names
+like `genkit-middleware/retry` resolve:
+
+```go
+import "github.com/firebase/genkit/go/plugins/middleware"
+
+g := genkit.Init(ctx, genkit.WithPlugins(
+	&googlegenai.GoogleAI{},
+	&middleware.Middleware{}, // registers genkit-middleware/{retry,fallback,filesystem,skills,toolApproval}
+))
+```
+
+Available named middleware: `genkit-middleware/retry`, `genkit-middleware/fallback`,
+`genkit-middleware/filesystem`, `genkit-middleware/skills`,
+`genkit-middleware/toolApproval`. See [references/middleware.md](middleware.md).
+
 ## Schemas
 
 ### DefineSchemaFor (from Go type)

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -37,6 +37,14 @@ export const myFlow = ai.defineFlow({
 });
 ```
 
+## Prompts (Dotprompt)
+
+`.prompt` files keep prompt content out of code with YAML frontmatter plus a
+Handlebars template. See [Dotprompt](references/dotprompt.md): `promptDir`,
+`ai.prompt()` (call/stream/render), variants, partials, named schemas via
+`ai.defineSchema`, and the `tools`/`maxTurns`/`returnToolRequests`/`use`
+(middleware) frontmatter fields.
+
 ## Agents (Beta)
 
 Genkit has a preview **agent** API for persistent, multi-turn conversations
@@ -134,6 +142,7 @@ The `genkit` CLI is your primary tool for development and documentation.
 ## References
 
 -   [Best Practices](references/best-practices.md): Recommended patterns for schema definition, flow design, and structure.
+-   [Dotprompt](references/dotprompt.md): `.prompt` files — `promptDir`, `ai.prompt()`, variants, partials, named schemas, and `tools`/`maxTurns`/`returnToolRequests`/`use` frontmatter.
 -   [Docs & CLI Reference](references/docs-and-cli.md): Documentation search, CLI tasks, and workflows.
 -   [Common Errors](references/common-errors.md): Critical "gotchas", migration guide, and troubleshooting.
 -   [Setup Guide](references/setup.md): Manual setup instructions for new projects.

--- a/skills/developing-genkit-js/references/dotprompt.md
+++ b/skills/developing-genkit-js/references/dotprompt.md
@@ -1,0 +1,207 @@
+# Dotprompt (.prompt files) — Genkit JS
+
+## What it is
+
+`.prompt` files combine YAML frontmatter (model, config, schemas, tools,
+middleware) with a Handlebars template. They keep prompt logic out of your
+TypeScript code and make variants and iteration easy.
+
+## Where files live
+
+By default Genkit loads `.prompt` files from `./prompts`. Configure with the
+`promptDir` option (set to `null` to disable auto-loading):
+
+```ts
+import { genkit } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+
+const ai = genkit({
+  plugins: [googleAI()],
+  promptDir: './prompts', // default
+});
+```
+
+## File format
+
+`prompts/recipe.prompt`:
+```
+---
+model: googleai/gemini-pro-latest
+input:
+  schema:
+    food: string
+    ingredients?(array): string   # ? = optional
+output:
+  schema: Recipe                  # references a schema registered via ai.defineSchema
+---
+You are a chef famous for creative recipes.
+
+Generate a recipe for {{food}}.
+
+{{#if ingredients}}
+Make sure to include the following ingredients:
+{{list ingredients}}
+{{/if}}
+```
+
+Schema fields use Picoschema (the compact form above) or you can reference a
+named schema registered with `ai.defineSchema`.
+
+## Loading and calling a prompt
+
+`ai.prompt(name, { variant? })` returns an `ExecutablePrompt`. The returned
+object is **callable** and also has `.stream()`, `.render()`, and `.asTool()`.
+
+```ts
+// Non-streaming: call it like a function with the input object.
+const recipePrompt = ai.prompt('recipe');
+const { output } = await recipePrompt({ food: 'banana bread' });
+
+// With a typed output schema
+const RecipeSchema = ai.defineSchema('Recipe', z.object({
+  title: z.string(),
+  steps: z.array(z.string()),
+}));
+const result = await ai.prompt<any, typeof RecipeSchema>('recipe')({ food: 'banana bread' });
+result.output; // typed as Recipe
+```
+
+### Streaming
+
+```ts
+const storyPrompt = ai.prompt('story');
+const { response, stream } = storyPrompt.stream({ subject: 'a robot' });
+for await (const chunk of stream) {
+  console.log(chunk.text);
+}
+const final = await response;
+```
+
+### Render without generating
+
+Useful for building `ai.generate` calls or LLM-judge evals:
+
+```ts
+const rendered = await ai.prompt('recipe').render({ food: 'banana bread' });
+// rendered is a GenerateOptions object (messages, model, config, ...)
+```
+
+## Registering named schemas
+
+Reference a schema by name in `.prompt` frontmatter (`input.schema` /
+`output.schema`) after registering it:
+
+```ts
+import { z } from 'genkit';
+
+const RecipeSchema = ai.defineSchema(
+  'Recipe',
+  z.object({
+    title: z.string().describe('recipe title'),
+    ingredients: z.array(z.object({ name: z.string(), quantity: z.string() })),
+    steps: z.array(z.string()).describe('the steps required'),
+  })
+);
+```
+
+## Variants
+
+Name the file `<name>.<variant>.prompt` — e.g. `recipe.robot.prompt`. Call with
+the `variant` option:
+
+```ts
+await ai.prompt('recipe', { variant: 'robot' })({ food: 'oil cake' });
+```
+
+## Partials
+
+Reusable template fragments. Name a partial file `_<name>.prompt` and include it
+with `{{>name param=value}}`.
+
+`prompts/_style.prompt`:
+```
+{{ role "system" }}
+You should speak as if you are a {{#if personality}}{{personality}}{{else}}pirate{{/if}}.
+{{role "user"}}
+```
+
+`prompts/story.prompt`:
+```
+---
+model: googleai/gemini-pro-latest
+input:
+  schema:
+    subject: string
+    personality?: string
+---
+{{>style personality=personality}}
+
+Tell me a story about {{subject}}.
+```
+
+## Helpers
+
+Register a function callable inside templates:
+
+```ts
+ai.defineHelper('list', (data: any) =>
+  Array.isArray(data) ? data.map((item) => `- ${item}`).join('\n') : ''
+);
+```
+
+Then use `{{list ingredients}}` in the template.
+
+## Tools, tool-loop control, and middleware
+
+`.prompt` frontmatter can configure tool calling and attach middleware, so an
+agent-style prompt is fully described in the file:
+
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    tone: string
+tools:
+  - getAttractions
+  - getFlightInfo
+toolChoice: auto          # auto | required | none
+maxTurns: 20              # max tool-call loop iterations
+returnToolRequests: false # return tool requests instead of running them
+use:
+  - name: retry           # bare string also works: `- retry`
+    config:
+      maxRetries: 4
+---
+{{role "system"}}
+You are a friendly trip planning assistant. Help users plan trips by suggesting
+attractions and looking up flight information. Keep your tone {{tone}}.
+
+{{history}}
+```
+
+- `tools`: list of registered tool names.
+- `toolChoice`, `maxTurns`, `returnToolRequests`: same semantics as the
+  equivalent `ai.generate` options.
+- `use`: list of middleware refs. Each entry is a bare string (middleware name)
+  or a map with `name` and optional `config`. Names resolve against middleware
+  registered on the Genkit instance — register the middleware plugin so the
+  name is available:
+
+```ts
+import { retry } from '@genkit-ai/middleware';
+
+const ai = genkit({
+  plugins: [googleAI(), retry.plugin()],
+  promptDir: './prompts',
+});
+```
+
+See [Using middleware](middleware.md) for the full list of built-in middleware.
+
+## Relationship to agents
+
+Agents (`defineAgent`) share the same dotprompt frontmatter — `system`/`prompt`,
+`tools`, `maxTurns`, `returnToolRequests`, and `use`. A `.prompt` file with
+`{{history}}` and tools can back an agent directly. See [Agents](agents.md).
+


### PR DESCRIPTION
Document the agent API for persistent multi-turn conversations in the Genkit Dart skill, including references for sessions, interrupts, branching, background execution, state, artifacts, multi-agent orchestration, custom agents, and deployment.