### PR TITLE
docs(genkit-dart): add gotchas for Firestore, state, and schemantic

### DIFF
--- a/skills/developing-genkit-dart/references/agents-sessions.md
+++ b/skills/developing-genkit-dart/references/agents-sessions.md
@@ -110,7 +110,6 @@ the exact pause point. They work with a store or with client-managed state
 
 ## Firestore session store (scalable)
 
-
 For production, `FirestoreSessionStore` (from `package:genkit_google_cloud`)
 persists each turn as an incremental JSON Patch diff anchored to periodic sharded
 checkpoints — no single document approaches Firestore's 1 MiB limit, and
@@ -130,6 +129,13 @@ final myAgent = ai.defineAgent(
   store: FirestoreSessionStore(),
 );
 ```
+
+> **Project id.** ADC alone may not carry a project id, so the default
+> `Firestore()` can fail at write time with `Project ID has not been discovered
+> yet. Initialize the SDK with credentials that include a project ID, set project
+> ID in Settings, or set the GOOGLE_CLOUD_PROJECT environment variable.` Export
+> `GOOGLE_CLOUD_PROJECT` (the Firestore client also reads a small set of standard
+> GCP project-id env vars), or pass an explicit `Firestore` via `db`.
 
 Options:
 

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -92,6 +92,21 @@ classes directly — no manual `Map` munging or `fromJson`. Assign back to the
 setters (e.g. `state.tasks = [...]`) so the mutated values are written to the
 session.
 
+> **Make computed/optional state fields nullable.** Non-nullable schemantic
+> getters are hard casts and throw (`Null is not a subtype of num`) when a
+> partially populated state blob is reloaded (e.g. a computed field that was
+> never written). Make such fields nullable or give them a `defaultValue`. See
+> [non-nullable getters throw on partial data](schemantic.md#non-nullable-getters-throw-on-partial-data).
+
+> **Prefer whole-collection tools over append-one-item tools.** The model may
+> emit several tool calls in a single **parallel** batch. Each
+> `session.updateCustom` reads the current custom state, mutates, and writes it
+> back; when the calls run in one batch they all read the same base and the last
+> write wins, silently dropping the others. An incremental `addTask` tool is only
+> safe if the model calls it sequentially. For anything the model may batch,
+> prefer a single idempotent "replace the whole collection" tool (e.g.
+> `setTasks(items: [...])`) that writes the entire collection in one call.
+
 `ai.currentSession<State>()` returns `null` when called outside an active session
 (e.g. a tool invoked without a running agent turn), so only use it inside agent
 tools.

--- a/skills/developing-genkit-dart/references/schemantic.md
+++ b/skills/developing-genkit-dart/references/schemantic.md
@@ -12,11 +12,20 @@ Always use `schemantic` when strongly typed JSON parsing or programmatic schema 
 
 ## Installation
 
-Add dependencies:
+Add dependencies. As of schemantic 0.2.x the code generator lives in a
+**separate** `schemantic_builder` package, so you must add it as a dev
+dependency too:
 
 ```bash
 dart pub add schemantic
+dart pub add dev:schemantic_builder
+dart pub add dev:build_runner
 ```
+
+> **Gotcha:** if `schemantic_builder` is missing, `dart run build_runner build`
+> completes "successfully" but reports `wrote 0 outputs` and generates no
+> `.g.dart` files, with no error explaining why. If you see zero outputs, confirm
+> `schemantic_builder` is in your `dev_dependencies`.
 
 ## Basic Usage
 
@@ -135,3 +144,13 @@ abstract class $Node {
 }
 ```
 *Note*: `Node.$schema.jsonSchema(useRefs: true)` generates schemas with JSON Schema `$ref`.
+
+## Non-nullable getters throw on partial data
+
+Generated getters for required fields are non-nullable casts (e.g.
+`_json['estimatedCostUsd'] as num`). A JSON blob that is missing such a field
+throws on access (`Null is not a subtype of num`) rather than returning a
+default — this commonly bites computed/optional values that were never written,
+e.g. when reloading a partially populated state blob. Make computed or optional
+fields nullable (`num?`) or give them a `defaultValue` so partial data can still
+be read.


### PR DESCRIPTION
Document common pitfalls in the developing-genkit-dart skill references:
- Firestore session store requires a project id via GOOGLE_CLOUD_PROJECT or explicit db
- Make computed/optional state fields nullable to avoid throws on partial data
- Prefer whole-collection tools over append-one-item tools to avoid lost writes in parallel batches
- schemantic 0.2.x requires the separate schemantic_builder dev dependency
- Non-nullable generated getters throw on missing fields in partial data