### PR TITLE
docs(python): add agents skill references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ npx skills add genkit-ai/skills --skill developing-genkit-dart
 npx skills add genkit-ai/skills --skill developing-genkit-go
 ```
 
+**For Python:**
+
+```bash
+npx skills add genkit-ai/skills --skill developing-genkit-python
+```
+
 ### Using tool-specific command
 
 For example (if using [Gemini CLI](https://geminicli.com/docs/cli/skills/#from-the-terminal)):
@@ -53,6 +59,12 @@ gemini skills install https://github.com/genkit-ai/skills.git --path skills/deve
 
 ```bash
 gemini skills install https://github.com/genkit-ai/skills.git --path skills/developing-genkit-go
+```
+
+**For Python:**
+
+```bash
+gemini skills install https://github.com/genkit-ai/skills.git --path skills/developing-genkit-python
 ```
 
 ### Manual Installation

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -64,9 +64,11 @@ first.
 
 **Common import traps:**
 
-- Google AI plugin: `from genkit_google_genai import GoogleAI` (not `genkit.plugins.google_genai`).
+- Google AI: `from genkit_google_genai import GoogleAI`
 - Agents: `from genkit.agent import InMemorySessionStore, ...`
-- Middleware: `from genkit_middleware import Middleware, ToolApproval, ...` (agents branch; older PyPI may still use `genkit.plugins.middleware`).
+- Middleware: `from genkit_middleware import Middleware, ToolApproval, ...`
+- FastAPI: `from genkit_fastapi import genkit_fastapi_handler, serve_agent`
+- Evaluators: `from genkit_evaluators import register_genkit_evaluators`
 
 ## Development Workflow
 

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -37,18 +37,16 @@ Genkit Python has a preview **agent** API for persistent, multi-turn
 conversations (sessions, snapshots, interrupts, branching, background
 execution). Types live under `genkit.agent`.
 
-Chat surface (Action-style): `await chat.send(...)` returns `AgentResponse`;
+Chat API: `await chat.send(...)` returns `AgentResponse`;
 `chat.send_stream(...)` returns an `AgentTurn` with `.stream` / `.response`.
-Same split for `resume` / `resume_stream`. Prefer `send` when you don't need
-chunks — you do not have to drain a stream for the turn to finish.
+Same split for `resume` / `resume_stream`. Use `send` when you don't need
+chunks — awaiting the response does not require draining the stream.
 
 **Requires a Genkit Python build that includes agents.** Stable PyPI `genkit`
 0.8.x does not yet export `define_agent` — install from the agents branch /
 checkout your team specifies until a release ships.
 
-For more details see:
-
-- [Agents](references/agents.md): defining/chatting with an agent and client-managed state (start here).
+- [Agents](references/agents.md): defining/chatting with an agent and client-managed state.
 - [Sessions & persistence](references/agents-sessions.md): session stores (`InMemory`/`File`/`Firestore`).
 - [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input and resuming.
 - [Branching](references/agents-branching.md): forking a conversation from a snapshot.
@@ -58,9 +56,11 @@ For more details see:
 - [Advanced custom agents](references/agents-custom.md): `define_custom_agent` for full turn control.
 - [HTTP clients](references/agents-http.md): `remote_agent` / `HttpAgentTransport`.
 
-## Critical: Do Not Trust Internal Knowledge
+## Verify against references
 
-The Python SDK changes often — verify imports and APIs against the references here or upstream docs. On **any** error, read [Common Errors](references/common-errors.md) first.
+The Python SDK changes often — check imports and APIs against the references
+here or upstream docs. On errors, see [Common Errors](references/common-errors.md)
+first.
 
 **Common import traps:**
 

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -37,6 +37,11 @@ Genkit Python has a preview **agent** API for persistent, multi-turn
 conversations (sessions, snapshots, interrupts, branching, background
 execution). Types live under `genkit.agent`.
 
+Chat surface (Action-style): `await chat.send(...)` returns `AgentResponse`;
+`chat.send_stream(...)` returns an `AgentTurn` with `.stream` / `.response`.
+Same split for `resume` / `resume_stream`. Prefer `send` when you don't need
+chunks — you do not have to drain a stream for the turn to finish.
+
 **Requires a Genkit Python build that includes agents.** Stable PyPI `genkit`
 0.8.x does not yet export `define_agent` — install from the agents branch /
 checkout your team specifies until a release ships.

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -7,7 +7,7 @@ description: Develop AI-powered applications using Genkit in Python. Use when th
 
 ## Prerequisites
 
-- **Runtime**: Python **3.14+**, **`uv`** for deps ([install](https://docs.astral.sh/uv/getting-started/installation/)).
+- **Runtime**: Python **3.10+**, **`uv`** for deps ([install](https://docs.astral.sh/uv/getting-started/installation/)).
 - **CLI**: `genkit --version` — install via `npm install -g genkit-cli` if missing.
 
 **New projects:** [Setup](references/setup.md) (bootstrap + env). **Patterns and code samples:** [Examples](references/examples.md).
@@ -16,7 +16,7 @@ description: Develop AI-powered applications using Genkit in Python. Use when th
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],
@@ -31,14 +31,42 @@ if __name__ == '__main__':
     ai.run_main(main())
 ```
 
+## Agents (Beta)
+
+Genkit Python has a preview **agent** API for persistent, multi-turn
+conversations (sessions, snapshots, interrupts, branching, background
+execution). Types live under `genkit.agent`.
+
+**Requires a Genkit Python build that includes agents.** Stable PyPI `genkit`
+0.8.x does not yet export `define_agent` — install from the agents branch /
+checkout your team specifies until a release ships.
+
+For more details see:
+
+- [Agents](references/agents.md): defining/chatting with an agent and client-managed state (start here).
+- [Sessions & persistence](references/agents-sessions.md): session stores (`InMemory`/`File`/`Firestore`).
+- [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input and resuming.
+- [Branching](references/agents-branching.md): forking a conversation from a snapshot.
+- [Background agents](references/agents-background.md): detaching long-running turns and polling.
+- [Working with state](references/agents-state.md): typed custom session state streamed to the client.
+- [Artifacts](references/agents-artifacts.md): producing and reading named deliverables.
+- [Advanced custom agents](references/agents-custom.md): `define_custom_agent` for full turn control.
+- [HTTP clients](references/agents-http.md): `remote_agent` / `HttpAgentTransport`.
+
 ## Critical: Do Not Trust Internal Knowledge
 
 The Python SDK changes often — verify imports and APIs against the references here or upstream docs. On **any** error, read [Common Errors](references/common-errors.md) first.
 
+**Common import traps:**
+
+- Google AI plugin: `from genkit_google_genai import GoogleAI` (not `genkit.plugins.google_genai`).
+- Agents: `from genkit.agent import InMemorySessionStore, ...`
+- Middleware: `from genkit_middleware import Middleware, ToolApproval, ...` (agents branch; older PyPI may still use `genkit.plugins.middleware`).
+
 ## Development Workflow
 
 1. Default provider: **Google AI** (`GoogleAI()`), **`GEMINI_API_KEY`** in the environment.
-2. Model IDs: always prefixed, e.g. **`googleai/gemini-flash-latest`** (always-on-latest Flash alias; same pattern as other skills).
+2. Model IDs: always prefixed, e.g. **`googleai/gemini-flash-latest`**.
 3. Entrypoint: **`ai.run_main(main())`** for Genkit-driven apps (not `asyncio.run()` for long-lived servers started with `genkit start` — see [Common Errors](references/common-errors.md)).
 4. After generating code, follow [Dev Workflow](references/dev-workflow.md) for `genkit start` and the Dev UI.
 5. On errors: step 1 is always [Common Errors](references/common-errors.md).
@@ -52,3 +80,4 @@ The Python SDK changes often — verify imports and APIs against the references 
 - [Dotprompt](references/dotprompt.md): `.prompt` files and helpers.
 - [Evals](references/evals.md): Evaluators and datasets.
 - [Dev Workflow](references/dev-workflow.md): `genkit start`, Dev UI, checklist.
+- [Agents (Beta)](references/agents.md): Agent basics and client-managed state. Deeper topics: [sessions](references/agents-sessions.md), [human-in-the-loop](references/agents-human-in-the-loop.md), [branching](references/agents-branching.md), [background](references/agents-background.md), [state](references/agents-state.md), [artifacts](references/agents-artifacts.md), [custom agents](references/agents-custom.md), [HTTP](references/agents-http.md).

--- a/skills/developing-genkit-python/references/agents-artifacts.md
+++ b/skills/developing-genkit-python/references/agents-artifacts.md
@@ -1,7 +1,7 @@
 # Working with Artifacts (Beta)
 
-> **Beta / preview API.** `Artifacts` middleware comes from `genkit_middleware`.
-> Read [agents.md](agents.md) first.
+> **Beta / preview API.** `Artifacts` middleware is from `genkit_middleware`.
+> See [agents.md](agents.md).
 
 **Artifacts** are named, content-bearing deliverables an agent produces during a
 session — files, reports, code, etc. They live in the session (deduplicated by

--- a/skills/developing-genkit-python/references/agents-artifacts.md
+++ b/skills/developing-genkit-python/references/agents-artifacts.md
@@ -1,0 +1,55 @@
+# Working with Artifacts (Beta)
+
+> **Beta / preview API.** `Artifacts` middleware comes from `genkit_middleware`.
+> Read [agents.md](agents.md) first.
+
+**Artifacts** are named, content-bearing deliverables an agent produces during a
+session — files, reports, code, etc. They live in the session (deduplicated by
+name) and are tracked on `chat.artifacts` / `res.artifacts`.
+
+## Give the model artifact tools
+
+```python
+from genkit_google_genai import GoogleAI
+from genkit_middleware import Artifacts, Middleware
+
+from genkit import Genkit
+from genkit.agent import InMemorySessionStore
+
+ai = Genkit(plugins=[GoogleAI(), Middleware()])
+
+agent = ai.define_agent(
+    name='workspaceAgent',
+    model='googleai/gemini-flash-latest',
+    system=(
+        'Code generation assistant. Use write_artifact to create files '
+        '(name + content). Use read_artifact to review prior files.'
+    ),
+    use=[Artifacts()],
+    store=InMemorySessionStore(),
+)
+
+chat = agent.chat()
+await chat.send('Write poem.txt with a short poem about Python agents.').response
+assert any(a.name == 'poem.txt' for a in chat.artifacts)
+```
+
+Writing the same `name` again **replaces** the artifact.
+
+## Programmatic access (custom agents)
+
+```python
+from genkit import Part, TextPart
+from genkit.agent import Artifact
+
+await sess.add_artifacts(
+    Artifact(name='notes.md', parts=[Part(TextPart(text='# Notes'))])
+)
+all_artifacts = await sess.get_artifacts()
+```
+
+## Reading on the client
+
+After each turn, inspect `chat.artifacts` or `res.artifacts`. Over HTTP,
+`remote_agent` tracks the same list on the chat when `state_management` is set
+appropriately (see [HTTP clients](agents-http.md)).

--- a/skills/developing-genkit-python/references/agents-artifacts.md
+++ b/skills/developing-genkit-python/references/agents-artifacts.md
@@ -30,7 +30,7 @@ agent = ai.define_agent(
 )
 
 chat = agent.chat()
-await chat.send('Write poem.txt with a short poem about Python agents.').response
+await chat.send('Write poem.txt with a short poem about Python agents.')
 assert any(a.name == 'poem.txt' for a in chat.artifacts)
 ```
 

--- a/skills/developing-genkit-python/references/agents-background.md
+++ b/skills/developing-genkit-python/references/agents-background.md
@@ -1,0 +1,77 @@
+# Background Agents / Detaching (Beta)
+
+> **Beta / preview API.** Detaching **requires a [session store](agents-sessions.md)** —
+> the server needs somewhere to write the result when background work finishes.
+> Read [agents.md](agents.md) first.
+
+Detaching runs a turn in the background: the server saves a `pending` snapshot
+and returns a `snapshot_id` **immediately**, keeps processing, then updates the
+snapshot to a terminal status (`completed` / `failed` / `aborted` / `expired`).
+The client polls for completion and can abort.
+
+## Define the agent (store required)
+
+```python
+from genkit.agent import InMemorySessionStore
+
+agent = ai.define_agent(
+    name='backgroundAgent',
+    model='googleai/gemini-flash-latest',
+    system='Senior research analyst. Produce a comprehensive markdown report.',
+    store=InMemorySessionStore(),  # REQUIRED for detach
+)
+```
+
+## Detach + wait / poll
+
+`chat.detach(message)` returns a `DetachedTask`. The detached turn's reply does
+**not** stream back into the original `chat` object — reload from the store when
+you need the messages.
+
+```python
+from genkit.agent import SnapshotStatus
+
+chat = agent.chat()
+task = await chat.detach('Write a report on renewable energy trends')
+print(task.snapshot_id)  # available immediately
+
+# Block until terminal:
+snapshot = await task.wait(interval=2.0)
+print(snapshot.status)  # completed | failed | aborted | expired
+
+# Or poll for a live UI:
+async for snap in task.poll(interval=2.0):
+    if snap.status == SnapshotStatus.COMPLETED:
+        break
+    if snap.status in (SnapshotStatus.FAILED, SnapshotStatus.ABORTED, SnapshotStatus.EXPIRED):
+        break
+
+# Cancel server-side work:
+await task.abort()
+```
+
+Reload results into a chat when you need the conversation view:
+
+```python
+done = await agent.load_chat(snapshot_id=task.snapshot_id)
+print(done.messages)
+```
+
+## Abort: client vs server (critical)
+
+| Call | Effect |
+|---|---|
+| `turn.abort()` | **Client detach** — stop listening; the server turn keeps running and may still persist. |
+| `asyncio.timeout` around stream/response | Same as `turn.abort()`, then re-raises `TimeoutError`. |
+| `chat.abort()` / `task.abort()` | **Server cancel** — needs a store; fires abort signal; snapshot settles `ABORTED` and is **not** a resume point. |
+
+After a server abort, reload the session leaf (last good snapshot), not the
+aborted one. After a successful detach, reload via `load_chat` to see the reply.
+
+## Status values
+
+- `pending` — still processing.
+- `completed` — finished successfully.
+- `failed` — error during processing.
+- `aborted` — cancelled via `abort()`.
+- `expired` — worker stopped responding (e.g. server restart); terminal.

--- a/skills/developing-genkit-python/references/agents-background.md
+++ b/skills/developing-genkit-python/references/agents-background.md
@@ -1,8 +1,8 @@
 # Background Agents / Detaching (Beta)
 
-> **Beta / preview API.** Detaching **requires a [session store](agents-sessions.md)** —
-> the server needs somewhere to write the result when background work finishes.
-> Read [agents.md](agents.md) first.
+> **Beta / preview API.** Detaching requires a
+> [session store](agents-sessions.md) so the server can persist the result.
+> See [agents.md](agents.md).
 
 Detaching runs a turn in the background: the server saves a `pending` snapshot
 and returns a `snapshot_id` **immediately**, keeps processing, then updates the

--- a/skills/developing-genkit-python/references/agents-branching.md
+++ b/skills/developing-genkit-python/references/agents-branching.md
@@ -1,0 +1,61 @@
+# Agent Branching (Beta)
+
+> **Beta / preview API.** Requires a [session store](agents-sessions.md). Read
+> [agents.md](agents.md) first.
+
+A `snapshot_id` is an **immutable checkpoint**, like a git commit. You can fork
+as many independent timelines as you want from the same snapshot — each turn
+from a snapshot creates a new, independent snapshot; the original is unchanged.
+
+To branch, load a chat attached to an earlier snapshot via
+`load_chat(snapshot_id=...)`.
+
+## Fork sibling timelines
+
+```python
+from genkit.agent import InMemorySessionStore
+
+# After a fork, session_id lookup is ambiguous — raise instead of guessing.
+store = InMemorySessionStore(reject_ambiguous_session=True)
+
+agent = ai.define_agent(
+    name='designer',
+    model='googleai/gemini-flash-latest',
+    system='You help design a product landing page. Reply briefly.',
+    store=store,
+)
+
+root = agent.chat()
+await root.send('Plan a landing page for a note-taking app.').response
+checkpoint = root.snapshot_id
+session_id = root.session_id
+
+# Two independent branches from the same checkpoint.
+minimal = await agent.load_chat(snapshot_id=checkpoint)
+await minimal.send('Direction: minimal.').response
+
+bold = await agent.load_chat(snapshot_id=checkpoint)
+await bold.send('Direction: bold.').response
+chosen_leaf = bold.snapshot_id
+
+# session_id can no longer mean "the latest turn" — Genkit raises
+# FAILED_PRECONDITION rather than silently picking a branch.
+# Resolve by resuming the specific leaf you want:
+resumed = await agent.load_chat(snapshot_id=chosen_leaf)
+await resumed.send('Add a pricing section.').response
+```
+
+## Time travel
+
+Same idea for "edit and resubmit": keep the earlier snapshot id, open a new chat
+from it, and send a different follow-up. The first answer remains as its own
+sibling leaf in the store.
+
+## Prefer snapshot_id after forks
+
+Once a session has multiple leaves, prefer `snapshot_id` over `session_id` for
+resume. With `reject_ambiguous_session=True`, ambiguous `session_id` lookups
+fail loudly (recommended for branching UIs).
+
+Abandoned branches simply remain in the store as immutable snapshots; nothing
+is overwritten when you branch.

--- a/skills/developing-genkit-python/references/agents-branching.md
+++ b/skills/developing-genkit-python/references/agents-branching.md
@@ -26,23 +26,23 @@ agent = ai.define_agent(
 )
 
 root = agent.chat()
-await root.send('Plan a landing page for a note-taking app.').response
+await root.send('Plan a landing page for a note-taking app.')
 checkpoint = root.snapshot_id
 session_id = root.session_id
 
 # Two independent branches from the same checkpoint.
 minimal = await agent.load_chat(snapshot_id=checkpoint)
-await minimal.send('Direction: minimal.').response
+await minimal.send('Direction: minimal.')
 
 bold = await agent.load_chat(snapshot_id=checkpoint)
-await bold.send('Direction: bold.').response
+await bold.send('Direction: bold.')
 chosen_leaf = bold.snapshot_id
 
 # session_id can no longer mean "the latest turn" — Genkit raises
 # FAILED_PRECONDITION rather than silently picking a branch.
 # Resolve by resuming the specific leaf you want:
 resumed = await agent.load_chat(snapshot_id=chosen_leaf)
-await resumed.send('Add a pricing section.').response
+await resumed.send('Add a pricing section.')
 ```
 
 ## Time travel

--- a/skills/developing-genkit-python/references/agents-branching.md
+++ b/skills/developing-genkit-python/references/agents-branching.md
@@ -1,7 +1,7 @@
 # Agent Branching (Beta)
 
-> **Beta / preview API.** Requires a [session store](agents-sessions.md). Read
-> [agents.md](agents.md) first.
+> **Beta / preview API.** Requires a [session store](agents-sessions.md).
+> See [agents.md](agents.md).
 
 A `snapshot_id` is an **immutable checkpoint**, like a git commit. You can fork
 as many independent timelines as you want from the same snapshot — each turn

--- a/skills/developing-genkit-python/references/agents-custom.md
+++ b/skills/developing-genkit-python/references/agents-custom.md
@@ -1,7 +1,7 @@
 # Advanced Custom Agents — `define_custom_agent` (Beta)
 
-> **Beta / preview API.** Read [agents.md](agents.md) and
-> [agent state](agents-state.md) first.
+> **Beta / preview API.** See [agents.md](agents.md) and
+> [agent state](agents-state.md).
 
 `define_agent` runs a single prompt + tool loop. When you need **full control of
 the turn** — multiple model calls, custom logic between them, manual

--- a/skills/developing-genkit-python/references/agents-custom.md
+++ b/skills/developing-genkit-python/references/agents-custom.md
@@ -1,0 +1,104 @@
+# Advanced Custom Agents — `define_custom_agent` (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) and
+> [agent state](agents-state.md) first.
+
+`define_agent` runs a single prompt + tool loop. When you need **full control of
+the turn** — multiple model calls, custom logic between them, manual
+message/state management, or custom progress streaming — use
+`ai.define_custom_agent`.
+
+## When to use it
+
+Reach for `define_custom_agent` when a turn needs to:
+
+- make **multiple model calls** with your own orchestration between them;
+- run **multi-step workflows** (decompose → research → synthesize);
+- **manually manage** messages and custom state;
+- **stream custom status** updates to the client mid-turn.
+
+Otherwise prefer `define_agent` (simpler; custom state still works via
+`state_schema`).
+
+## Signature
+
+```python
+async def fn(sess: SessionRunner, ctx: ActionRunContext) -> AgentResult:
+    async def handle_turn(inp: AgentInput, turn_ctx: TurnContext) -> TurnResult | None:
+        ...
+        return TurnResult(finish_reason=AgentFinishReason.STOP)
+
+    await sess.run(handle_turn)
+    return await sess.result()
+
+agent = ai.define_custom_agent(
+    name='customCoder',
+    fn=fn,
+    store=store,                 # optional
+    state_schema=MyState,        # optional
+)
+```
+
+Key pieces:
+
+- `sess.run(handle_turn)` — runs the turn loop; adds the incoming user message
+  before calling your handler so `get_messages()` includes it.
+- `sess.get_messages` / `add_messages` / `set_messages`
+- `sess.get_custom` / `update_custom`
+- `sess.get_artifacts` / `add_artifacts`
+- `ctx.send_chunk(AgentStreamChunk(...))` — stream to the client
+- `turn_ctx.snapshot_id` — reserved when a store is present (useful as an
+  external workspace key for the turn)
+
+## Example: streaming custom agent
+
+```python
+from genkit import ActionRunContext, FinishReason, Genkit, Message
+from genkit.agent import (
+    AgentFinishReason,
+    AgentInput,
+    AgentResult,
+    AgentStreamChunk,
+    InMemorySessionStore,
+    SessionRunner,
+    TurnContext,
+    TurnResult,
+)
+
+ai = Genkit(plugins=[GoogleAI()])
+store = InMemorySessionStore()
+
+
+async def custom_coder_fn(sess: SessionRunner, ctx: ActionRunContext) -> AgentResult:
+    async def handle_turn(inp: AgentInput, _: TurnContext) -> TurnResult | None:
+        history = await sess.get_messages()
+        messages = [Message(m) for m in history] if history else None
+
+        stream_resp = ai.generate_stream(
+            model='googleai/gemini-flash-latest',
+            system='Concise coding assistant.',
+            messages=messages,
+        )
+        async for chunk in stream_resp.stream:
+            ctx.send_chunk(AgentStreamChunk(model_chunk=chunk))
+
+        res = await stream_resp.response
+        if res.message:
+            await sess.add_messages(res.message)
+
+        fr = (
+            AgentFinishReason.STOP
+            if res.finish_reason == FinishReason.STOP
+            else AgentFinishReason.UNKNOWN
+        )
+        return TurnResult(finish_reason=fr)
+
+    await sess.run(handle_turn)
+    return await sess.result()
+
+
+agent = ai.define_custom_agent(name='customCoder', fn=custom_coder_fn, store=store)
+```
+
+From the caller's side, `agent.chat().send(...)` works the same as a prompt
+agent — sessions, streaming, and the store are unchanged.

--- a/skills/developing-genkit-python/references/agents-http.md
+++ b/skills/developing-genkit-python/references/agents-http.md
@@ -23,7 +23,7 @@ client = remote_agent(
 )
 
 chat = client.chat()
-turn = chat.send('Weather in Tokyo?')
+turn = chat.send_stream('Weather in Tokyo?')
 async for chunk in turn.stream:
     if chunk.text:
         print(chunk.text, end='', flush=True)

--- a/skills/developing-genkit-python/references/agents-http.md
+++ b/skills/developing-genkit-python/references/agents-http.md
@@ -1,0 +1,59 @@
+# Agent HTTP Clients (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) first.
+
+Python exposes a client-side HTTP transport so one process can talk to an agent
+served elsewhere. There is **not** yet a dedicated FastAPI helper that mounts an
+agent the way `genkit_fastapi_handler` mounts flows — server exposure is typically
+via the Genkit reflection / action HTTP surface or a custom route that streams
+the agent action. The **client** API below is ready to use.
+
+## `remote_agent`
+
+```python
+from genkit.agent import remote_agent
+
+client = remote_agent(
+    url='https://host/api/myAgent',
+    state_management='server',  # or 'client' — required
+    # Optional overrides (default to `{url}/getSnapshot` and `{url}/abort`):
+    # get_snapshot_url='...',
+    # abort_url='...',
+    # headers={'Authorization': 'Bearer ...'},  # or a sync/async callable
+)
+
+chat = client.chat()
+turn = chat.send('Weather in Tokyo?')
+async for chunk in turn.stream:
+    if chunk.text:
+        print(chunk.text, end='', flush=True)
+res = await turn.response
+print(res.snapshot_id, chat.snapshot_id)
+```
+
+`state_management`:
+
+- `'server'` — server has a store; client tracks `snapshot_id` / `session_id`.
+- `'client'` — no server store; client round-trips the state blob each turn.
+
+The returned client has the same `chat` / `load_chat` / `send` / `resume` /
+`detach` surface as an in-process `Agent`.
+
+## Wire shape (for custom servers)
+
+Turns are POST requests with JSON body roughly:
+
+```json
+{ "data": { /* AgentInput */ }, "init": { /* AgentInit */ } }
+```
+
+and `Accept: text/event-stream`. Stream events are `data: {...}` lines (chunks,
+then a final `result`). Companion endpoints:
+
+- `POST {url}/getSnapshot` — lookup by `snapshotId` or `sessionId`
+- `POST {url}/abort` — abort a running snapshot
+
+## Errors
+
+Transport and failed turns surface as `AgentError` (from `genkit.agent`) with
+`message`, `status`, `details`, and optionally `snapshot_id` / `state`.

--- a/skills/developing-genkit-python/references/agents-http.md
+++ b/skills/developing-genkit-python/references/agents-http.md
@@ -1,6 +1,6 @@
 # Agent HTTP Clients (Beta)
 
-> **Beta / preview API.** Read [agents.md](agents.md) first.
+> **Beta / preview API.** See [agents.md](agents.md).
 
 Python exposes a client-side HTTP transport so one process can talk to an agent
 served elsewhere. There is **not** yet a dedicated FastAPI helper that mounts an

--- a/skills/developing-genkit-python/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-python/references/agents-human-in-the-loop.md
@@ -1,13 +1,13 @@
 # Agent Human-in-the-Loop / Interrupts (Beta)
 
-> **Beta / preview API.** Read [agents.md](agents.md) first.
+> **Beta / preview API.** See [agents.md](agents.md).
 
 An **interrupt** pauses an agent mid-turn and hands control back to your code (or
 a human) — e.g. to approve a sensitive tool before it runs. You then **resume**
 from the exact point it paused.
 
-Interrupts are **orthogonal to persistence** — they work the same whether the
-agent uses a [session store](agents-sessions.md) or
+Interrupts work the same whether the agent uses a
+[session store](agents-sessions.md) or
 [client-managed state](agents.md#client-managed-state-no-server-store).
 
 Flow: `chat.send(...)` → response has `finish_reason == INTERRUPTED` and

--- a/skills/developing-genkit-python/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-python/references/agents-human-in-the-loop.md
@@ -1,0 +1,119 @@
+# Agent Human-in-the-Loop / Interrupts (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) first.
+
+An **interrupt** pauses an agent mid-turn and hands control back to your code (or
+a human) — e.g. to approve a sensitive tool before it runs. You then **resume**
+from the exact point it paused.
+
+Interrupts are **orthogonal to persistence** — they work the same whether the
+agent uses a [session store](agents-sessions.md) or
+[client-managed state](agents.md#client-managed-state-no-server-store).
+
+Flow: `chat.send(...)` → response has `finish_reason == INTERRUPTED` and
+`res.interrupts` → collect human input → `chat.resume(...)`.
+
+## ToolApproval middleware (common path)
+
+`ToolApproval` interrupts before tools run. Tools listed in `allowed_tools` run
+without prompting; everything else pauses. An empty list means **every** tool
+needs approval.
+
+```python
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+from genkit_google_genai import GoogleAI
+from genkit_middleware import Middleware, ToolApproval
+
+from genkit import Genkit, ToolRequestPart
+from genkit.agent import AgentFinishReason, InMemorySessionStore
+
+ai = Genkit(plugins=[GoogleAI(), Middleware()])
+tool_approval = ToolApproval(allowed_tools=[])  # approve all tools
+
+
+class TransferInput(BaseModel):
+    amount: float
+    to_account: str = Field(alias='toAccount')
+
+
+class TransferOutput(BaseModel):
+    success: bool
+    transaction_id: str = Field(alias='transactionId')
+
+
+@ai.tool(name='transferMoney', description='Transfer money between accounts.')
+async def transfer_money(input: TransferInput) -> TransferOutput:
+    return TransferOutput(success=True, transactionId=f'txn-{uuid4().hex[:12]}')
+
+
+agent = ai.define_agent(
+    name='bankingAgent',
+    model='googleai/gemini-flash-latest',
+    system='Banking assistant. Call transferMoney when the user asks to transfer money.',
+    tools=[transfer_money],
+    use=[tool_approval],
+    store=InMemorySessionStore(),
+)
+```
+
+## Detect and resume
+
+```python
+chat = agent.chat()
+
+out1 = await chat.send('Transfer $500 to account 12345 for rent.').response
+assert out1.finish_reason == AgentFinishReason.INTERRUPTED
+# transferMoney is pending — it has NOT executed yet.
+
+# Approve each pending tool call, then one resume continues the turn.
+restart_parts: list[ToolRequestPart] = [
+    intr.restart(resumed_metadata={'tool_approved': True}) for intr in out1.interrupts
+]
+out2 = await chat.resume(restart=restart_parts).response
+assert out2.finish_reason == AgentFinishReason.STOP
+```
+
+Notes on resume helpers:
+
+- `interrupt.restart(...)` — re-issues the original tool request so the tool
+  actually runs (used by ToolApproval after human OK). Accepts
+  `resumed_metadata={'tool_approved': True}` (camelCase `toolApproved` also works).
+- `interrupt.respond(output)` — supplies a tool response **without** executing
+  the tool (useful for custom interrupt tools that collect human input).
+- Both are **builders**. They return parts; you still call `chat.resume(...)`.
+
+You can mix respond and restart:
+
+```python
+await chat.resume(
+    respond=[a.respond({'approved': True})],
+    restart=[b.restart(resumed_metadata={'tool_approved': True})],
+).response
+```
+
+Streaming works the same way — `chat.resume(...)` returns an `AgentTurn`:
+
+```python
+turn = chat.resume(restart=restart_parts)
+async for chunk in turn.stream:
+    if chunk.text:
+        print(chunk.text, end='', flush=True)
+final = await turn.response
+```
+
+## Without a store
+
+Interrupts still work. Keep the same `chat` object across send → resume, or
+round-trip `messages` / `state` / `artifacts` yourself when opening a new chat
+(see [client-managed state](agents.md#client-managed-state-no-server-store)).
+
+## Gotchas
+
+- Always build resume parts from `res.interrupts` — hand-rolled parts are
+  rejected by resume validation.
+- After resuming, the new response may interrupt again; loop until
+  `finish_reason` is no longer `INTERRUPTED`.
+- Don't treat an interrupted turn as a final model reply in the UI — show the
+  approval UI from `interrupt` input, then render the reply after resume.

--- a/skills/developing-genkit-python/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-python/references/agents-human-in-the-loop.md
@@ -63,7 +63,7 @@ agent = ai.define_agent(
 ```python
 chat = agent.chat()
 
-out1 = await chat.send('Transfer $500 to account 12345 for rent.').response
+out1 = await chat.send('Transfer $500 to account 12345 for rent.')
 assert out1.finish_reason == AgentFinishReason.INTERRUPTED
 # transferMoney is pending — it has NOT executed yet.
 
@@ -71,7 +71,7 @@ assert out1.finish_reason == AgentFinishReason.INTERRUPTED
 restart_parts: list[ToolRequestPart] = [
     intr.restart(resumed_metadata={'tool_approved': True}) for intr in out1.interrupts
 ]
-out2 = await chat.resume(restart=restart_parts).response
+out2 = await chat.resume(restart=restart_parts)
 assert out2.finish_reason == AgentFinishReason.STOP
 ```
 
@@ -90,13 +90,13 @@ You can mix respond and restart:
 await chat.resume(
     respond=[a.respond({'approved': True})],
     restart=[b.restart(resumed_metadata={'tool_approved': True})],
-).response
+)
 ```
 
-Streaming works the same way — `chat.resume(...)` returns an `AgentTurn`:
+Streaming resume uses `resume_stream` (same split as `send` / `send_stream`):
 
 ```python
-turn = chat.resume(restart=restart_parts)
+turn = chat.resume_stream(restart=restart_parts)
 async for chunk in turn.stream:
     if chunk.text:
         print(chunk.text, end='', flush=True)

--- a/skills/developing-genkit-python/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-python/references/agents-human-in-the-loop.md
@@ -93,7 +93,7 @@ await chat.resume(
 )
 ```
 
-Streaming resume uses `resume_stream` (same split as `send` / `send_stream`):
+Streaming resume:
 
 ```python
 turn = chat.resume_stream(restart=restart_parts)

--- a/skills/developing-genkit-python/references/agents-sessions.md
+++ b/skills/developing-genkit-python/references/agents-sessions.md
@@ -1,8 +1,8 @@
 # Agent Sessions & Persistence (Beta)
 
-> **Beta / preview API.** Session stores are imported from `genkit.agent`
+> **Beta / preview API.** Session stores: `genkit.agent`
 > (`InMemorySessionStore`, `FileSessionStore`) and `genkit_google_cloud`
-> (`FirestoreSessionStore`). See [agents.md](agents.md) for the basics first.
+> (`FirestoreSessionStore`). See [agents.md](agents.md).
 
 When an agent has a `store`, the **server** owns the session history. Each turn
 produces an immutable **snapshot**; the snapshot chain is what carries

--- a/skills/developing-genkit-python/references/agents-sessions.md
+++ b/skills/developing-genkit-python/references/agents-sessions.md
@@ -1,0 +1,129 @@
+# Agent Sessions & Persistence (Beta)
+
+> **Beta / preview API.** Session stores are imported from `genkit.agent`
+> (`InMemorySessionStore`, `FileSessionStore`) and `genkit_google_cloud`
+> (`FirestoreSessionStore`). See [agents.md](agents.md) for the basics first.
+
+When an agent has a `store`, the **server** owns the session history. Each turn
+produces an immutable **snapshot**; the snapshot chain is what carries
+conversation state forward. A store also enables [branching](agents-branching.md)
+and [background execution](agents-background.md). (Interrupts work with or without
+a store — see [human-in-the-loop](agents-human-in-the-loop.md).)
+
+## Pick a store
+
+```python
+from genkit.agent import InMemorySessionStore, FileSessionStore
+
+# In-memory: great for tests/dev; lost on process restart.
+mem_store = InMemorySessionStore()
+
+# File-backed: one JSON file per snapshot under the directory.
+file_store = FileSessionStore('./.snapshots')
+
+# Optional: prune long chains; reject ambiguous session_id lookups after forks.
+pruning = FileSessionStore(
+    './.snapshots',
+    max_persisted_chain_length=3,
+    reject_ambiguous_session=True,
+)
+```
+
+Attach it to the agent:
+
+```python
+agent = ai.define_agent(
+    name='logbookAgent',
+    model='googleai/gemini-flash-latest',
+    system='You are a personal logbook assistant.',
+    store=file_store,
+)
+```
+
+A single `chat` persists to the store and threads the snapshot forward
+automatically:
+
+```python
+chat = agent.chat()
+res1 = await chat.send('Log this: I started studying Genkit today.').response
+res2 = await chat.send('What did I study today?').response  # remembers turn 1
+print(res1.snapshot_id, res2.snapshot_id)
+```
+
+Resume a prior conversation by snapshot id:
+
+```python
+resumed = await agent.load_chat(snapshot_id=res2.snapshot_id)
+await resumed.send('Add another note.').response
+```
+
+## Typed session state
+
+Use `state_schema` (a Pydantic model) to attach typed custom state. Loaded
+snapshots validate against it; `chat.state` and streamed `chunk.custom` become
+instances of that model.
+
+```python
+from pydantic import BaseModel
+
+from genkit.agent import InMemorySessionStore
+
+
+class Profile(BaseModel):
+    name: str
+    tier: str = 'free'
+
+
+agent = ai.define_agent(
+    name='profileAgent',
+    model='googleai/gemini-flash-latest',
+    system='Greet the user by name and tailor answers to their tier.',
+    store=InMemorySessionStore(),
+    state_schema=Profile,
+)
+
+# Seed custom state when opening the chat.
+chat = agent.chat(state=Profile(name='Ada', tier='pro'))
+```
+
+See [Working with state](agents-state.md) for streaming custom patches from a
+custom agent.
+
+## Firestore session store (scalable, Beta)
+
+For production, `FirestoreSessionStore` (from `genkit_google_cloud`) persists
+each turn as an incremental diff anchored to periodic checkpoints.
+
+```python
+from genkit_google_cloud import FirestoreSessionStore
+
+agent = ai.define_agent(
+    name='myAgent',
+    model='googleai/gemini-flash-latest',
+    system='You are a helpful assistant.',
+    # Defaults to AsyncClient() using Application Default Credentials.
+    store=FirestoreSessionStore(),
+)
+```
+
+Useful options:
+
+- `client` / `sync_client`: explicit Firestore clients.
+- `collection`: snapshot collection (default `"genkit-sessions"`).
+- `checkpoint_interval`: turns between full-state checkpoints (default `25`).
+- `shard_size`: max bytes per shard/diff document.
+- `reject_ambiguous_session`: raise on ambiguous `session_id` after a fork.
+
+Install: `uv add genkit-plugin-google-cloud` (import remains `genkit_google_cloud`).
+
+## What a store unlocks
+
+| Capability | Needs store? |
+|---|---|
+| Multi-turn on one `chat` object | No |
+| Durable `snapshot_id` / `session_id` | **Yes** |
+| `load_chat(snapshot_id=...)` | **Yes** |
+| Branching / time-travel | **Yes** |
+| `chat.detach(...)` / background tasks | **Yes** |
+| Server-side `chat.abort()` / `task.abort()` | **Yes** |
+| Interrupts / ToolApproval | No (works either way) |

--- a/skills/developing-genkit-python/references/agents-sessions.md
+++ b/skills/developing-genkit-python/references/agents-sessions.md
@@ -45,8 +45,8 @@ automatically:
 
 ```python
 chat = agent.chat()
-res1 = await chat.send('Log this: I started studying Genkit today.').response
-res2 = await chat.send('What did I study today?').response  # remembers turn 1
+res1 = await chat.send('Log this: I started studying Genkit today.')
+res2 = await chat.send('What did I study today?')  # remembers turn 1
 print(res1.snapshot_id, res2.snapshot_id)
 ```
 
@@ -54,7 +54,7 @@ Resume a prior conversation by snapshot id:
 
 ```python
 resumed = await agent.load_chat(snapshot_id=res2.snapshot_id)
-await resumed.send('Add another note.').response
+await resumed.send('Add another note.')
 ```
 
 ## Typed session state

--- a/skills/developing-genkit-python/references/agents-state.md
+++ b/skills/developing-genkit-python/references/agents-state.md
@@ -34,7 +34,7 @@ agent = ai.define_agent(
 )
 
 chat = agent.chat(state=Profile(name='Ada', tier='pro'))
-res = await chat.send('Hello').response
+res = await chat.send('Hello')
 print(chat.state.name)  # typed
 ```
 
@@ -95,7 +95,7 @@ agent = ai.define_custom_agent(
 )
 
 chat = agent.chat()
-turn = chat.send('Go')
+turn = chat.send_stream('Go')
 async for chunk in turn.stream:
     if chunk.custom is not None:
         print(chunk.custom.turns)  # Progress, not a dict

--- a/skills/developing-genkit-python/references/agents-state.md
+++ b/skills/developing-genkit-python/references/agents-state.md
@@ -1,0 +1,111 @@
+# Working with Agent State (Beta)
+
+> **Beta / preview API.** Read [agents.md](agents.md) and
+> [sessions](agents-sessions.md) first.
+
+Session state has three layers:
+
+- **messages** — the conversation transcript.
+- **custom** — your typed app state (`state_schema`).
+- **artifacts** — named deliverables (see [artifacts](agents-artifacts.md)).
+
+With `state_schema`, `chat.state`, `response.state`, and streamed `chunk.custom`
+are instances of that Pydantic model (attribute access, not dict keys).
+
+## Typed custom state on a prompt agent
+
+```python
+from pydantic import BaseModel
+
+from genkit.agent import InMemorySessionStore
+
+
+class Profile(BaseModel):
+    name: str
+    tier: str = 'free'
+
+
+agent = ai.define_agent(
+    name='profileAgent',
+    model='googleai/gemini-flash-latest',
+    system='Greet the user by name.',
+    store=InMemorySessionStore(),
+    state_schema=Profile,
+)
+
+chat = agent.chat(state=Profile(name='Ada', tier='pro'))
+res = await chat.send('Hello').response
+print(chat.state.name)  # typed
+```
+
+## Streaming custom patches from a custom agent
+
+Inside `define_custom_agent`, call `sess.update_custom(...)` to mutate custom
+state. Clients see live `chunk.custom` updates:
+
+```python
+from pydantic import BaseModel
+
+from genkit import ActionRunContext, FinishReason, Genkit, Message
+from genkit.agent import (
+    AgentFinishReason,
+    AgentInput,
+    AgentResult,
+    AgentStreamChunk,
+    InMemorySessionStore,
+    SessionRunner,
+    TurnContext,
+    TurnResult,
+)
+
+
+class Progress(BaseModel):
+    turns: int = 0
+
+
+async def stateful_fn(sess: SessionRunner, ctx: ActionRunContext) -> AgentResult:
+    async def handle_turn(inp: AgentInput, _: TurnContext) -> TurnResult | None:
+        await sess.update_custom(lambda c: {'turns': (c or {}).get('turns', 0) + 1})
+
+        history = await sess.get_messages()
+        messages = [Message(m) for m in history] if history else None
+        stream_resp = ai.generate_stream(
+            model='googleai/gemini-flash-latest',
+            system='Acknowledge progress in one sentence.',
+            messages=messages,
+        )
+        async for chunk in stream_resp.stream:
+            ctx.send_chunk(AgentStreamChunk(model_chunk=chunk))
+
+        res = await stream_resp.response
+        if res.message:
+            await sess.add_messages(res.message)
+        fr = AgentFinishReason.STOP if res.finish_reason == FinishReason.STOP else AgentFinishReason.UNKNOWN
+        return TurnResult(finish_reason=fr)
+
+    await sess.run(handle_turn)
+    return await sess.result()
+
+
+agent = ai.define_custom_agent(
+    name='statefulAgent',
+    fn=stateful_fn,
+    store=InMemorySessionStore(),
+    state_schema=Progress,
+)
+
+chat = agent.chat()
+turn = chat.send('Go')
+async for chunk in turn.stream:
+    if chunk.custom is not None:
+        print(chunk.custom.turns)  # Progress, not a dict
+final = await turn.response
+```
+
+## Client transforms (egress only)
+
+`state_transform` / `chunk_transform` on `define_agent` run on the way **out** to
+the client. They do not rewrite what the store persists.
+
+- `state_transform` must return a `SessionState` (never `None` to clear).
+- `chunk_transform` may return `None` to drop a chunk (e.g. redact secrets).

--- a/skills/developing-genkit-python/references/agents-state.md
+++ b/skills/developing-genkit-python/references/agents-state.md
@@ -1,7 +1,7 @@
 # Working with Agent State (Beta)
 
-> **Beta / preview API.** Read [agents.md](agents.md) and
-> [sessions](agents-sessions.md) first.
+> **Beta / preview API.** See [agents.md](agents.md) and
+> [sessions](agents-sessions.md).
 
 Session state has three layers:
 

--- a/skills/developing-genkit-python/references/agents.md
+++ b/skills/developing-genkit-python/references/agents.md
@@ -124,18 +124,23 @@ coding_agent = ai.define_agent(
 ## Chat with an agent
 
 `agent.chat()` opens a conversation. One `chat` carries state forward across
-turns. There is **no `send_stream`** — streaming is on the turn object.
+turns. The split matches `Action.run` / `Action.stream` (and `ai.generate` /
+`ai.generate_stream`):
+
+- `await chat.send(...)` — primary path; returns the completed `AgentResponse`
+- `chat.send_stream(...)` — same turn, with `.stream` / `.response` for chunks
+- `await chat.resume(...)` / `chat.resume_stream(...)` — same split after an interrupt
 
 ```python
 chat = agent.chat()
 
-# Non-streaming: await the response directly.
-res = await chat.send('Weather in Tokyo?').response
+# Non-streaming (primary):
+res = await chat.send('Weather in Tokyo?')
 print(res.text)
 print(res.snapshot_id)  # immutable checkpoint id (None if no store)
 
-# Streaming: iterate turn.stream, then await turn.response.
-turn = chat.send('What about Paris?')
+# Streaming:
+turn = chat.send_stream('What about Paris?')
 async for chunk in turn.stream:
     if chunk.text:
         print(chunk.accumulated_text, end='\r', flush=True)
@@ -151,7 +156,7 @@ With a store, hold onto `snapshot_id` and rehydrate later:
 ```python
 checkpoint = res.snapshot_id
 resumed = await agent.load_chat(snapshot_id=checkpoint)
-await resumed.send('What city did I ask about?').response
+await resumed.send('What city did I ask about?')
 ```
 
 You can also open `agent.chat(snapshot_id=...)` when you already know the id.
@@ -170,11 +175,11 @@ agent = ai.define_agent(
 )
 
 chat = agent.chat()
-await chat.send('My name is Ada. Remember it.').response
+await chat.send('My name is Ada. Remember it.')
 
 messages, state, artifacts = chat.messages, chat.state, chat.artifacts
 resumed = agent.chat(messages=messages, state=state, artifacts=artifacts)
-await resumed.send('What is my name? One word.').response
+await resumed.send('What is my name? One word.')
 ```
 
 Use client-managed state when you don't want server-side storage. Use a
@@ -189,7 +194,7 @@ For apps started with `genkit start`, use `ai.run_main(main())`:
 ```python
 async def main() -> None:
     chat = agent.chat()
-    print((await chat.send('hi').response).text)
+    print((await chat.send('hi')).text)
 
 if __name__ == '__main__':
     ai.run_main(main())

--- a/skills/developing-genkit-python/references/agents.md
+++ b/skills/developing-genkit-python/references/agents.md
@@ -124,28 +124,43 @@ coding_agent = ai.define_agent(
 ## Chat with an agent
 
 `agent.chat()` opens a conversation. One `chat` carries state forward across
-turns. The split matches `Action.run` / `Action.stream` (and `ai.generate` /
-`ai.generate_stream`):
+turns. Prefer the **Action-style** split (same idea as `ai.generate` /
+`ai.generate_stream` and `Action.run` / `Action.stream`):
 
-- `await chat.send(...)` — primary path; returns the completed `AgentResponse`
-- `chat.send_stream(...)` — same turn, with `.stream` / `.response` for chunks
-- `await chat.resume(...)` / `chat.resume_stream(...)` — same split after an interrupt
+| Method | Returns | When to use |
+| --- | --- | --- |
+| `await chat.send(...)` | `AgentResponse` | Primary path — you only need the final result |
+| `chat.send_stream(...)` | `AgentTurn` (`.stream` / `.response`) | You want incremental chunks |
+| `await chat.resume(...)` | `AgentResponse` | Continue after an interrupt (non-streaming) |
+| `chat.resume_stream(...)` | `AgentTurn` | Continue after an interrupt (streaming) |
 
 ```python
 chat = agent.chat()
 
-# Non-streaming (primary):
+# Non-streaming (primary) — prefer this when you don't need chunks:
 res = await chat.send('Weather in Tokyo?')
 print(res.text)
 print(res.snapshot_id)  # immutable checkpoint id (None if no store)
 
-# Streaming:
+# Streaming — same turn, with a live chunk view:
 turn = chat.send_stream('What about Paris?')
 async for chunk in turn.stream:
     if chunk.text:
         print(chunk.accumulated_text, end='\r', flush=True)
 final = await turn.response
+# or: final = await turn
 ```
+
+### Streaming semantics (important)
+
+- **You do not have to drain chunks.** `await turn.response` (or `await turn`)
+  completes whether or not you read `.stream`. Custom-state patches and
+  message stitching still apply — the client pumps the transport internally.
+- **Chunks are per-turn.** Each `send_stream` / `resume_stream` has its own
+  buffer. Unread chunks from turn N do **not** show up on turn N+1's stream.
+  Dropping the turn handle (or draining it later) is how unread chunks go away.
+- **Don't overlap sends on one `chat`.** Turns are single-flight; overlapping
+  `send` / `send_stream` on the same session can corrupt local history.
 
 Follow-up turns on the same `chat` remember prior context automatically.
 

--- a/skills/developing-genkit-python/references/agents.md
+++ b/skills/developing-genkit-python/references/agents.md
@@ -1,0 +1,196 @@
+# Agents (Beta)
+
+> **Beta / preview API.** Agents landed recently in Genkit Python. Public types
+> live under `genkit.agent`. Import paths and signatures may still change.
+>
+> **Requires a Genkit Python build that includes agents.** Stable PyPI `genkit`
+> 0.8.x does **not** yet export `define_agent`. Install from the agents branch /
+> local checkout your team points you at (or a newer release once published).
+
+An **agent** is a persistent, multi-turn conversation primitive built on prompts
++ tools. Compared to a bare `ai.generate` loop, an agent adds:
+
+- **Sessions**: multi-turn history tracked as immutable **snapshots**.
+- **State**: typed session state (messages + custom data + artifacts).
+- **Interrupts**: human-in-the-loop pause/resume.
+- **Branching**: fork a conversation from any snapshot.
+- **Detaching**: run a turn in the background and poll for the result.
+
+Progressive disclosure — read the file for the level you need:
+
+- This file: defining an agent, chatting, streaming, and **client-managed state** (no store).
+- [Sessions & persistence](agents-sessions.md): `SessionStore`, `InMemorySessionStore`, `FileSessionStore`, `FirestoreSessionStore`.
+- [Human-in-the-loop / interrupts](agents-human-in-the-loop.md): pausing for approval/input and resuming.
+- [Branching](agents-branching.md): forking a conversation from a snapshot.
+- [Background agents](agents-background.md): detaching long-running turns and polling.
+- [Working with state](agents-state.md): typed custom session state streamed to the client.
+- [Artifacts](agents-artifacts.md): producing/reading named deliverables.
+- [Advanced custom agents](agents-custom.md): `define_custom_agent` for full turn control.
+- [HTTP clients](agents-http.md): `remote_agent` / `HttpAgentTransport`.
+
+## Setup
+
+```python
+from genkit import Genkit
+from genkit_google_genai import GoogleAI
+
+ai = Genkit(
+    plugins=[GoogleAI()],
+    model='googleai/gemini-flash-latest',
+)
+```
+
+## Define an agent
+
+`ai.define_agent` combines prompt + tool config + (optional) session store into a
+single registered action.
+
+```python
+from pydantic import BaseModel
+
+from genkit import Genkit
+from genkit_google_genai import GoogleAI
+from genkit.agent import InMemorySessionStore
+
+ai = Genkit(plugins=[GoogleAI()])
+
+
+class WeatherInput(BaseModel):
+    location: str
+
+
+class WeatherOutput(BaseModel):
+    weather: str
+    temperature: str
+
+
+@ai.tool(name='getWeather', description='Get weather for a city.')
+async def get_weather(input: WeatherInput) -> WeatherOutput:
+    return WeatherOutput(weather='Sunny', temperature='21°C')
+
+
+agent = ai.define_agent(
+    name='weatherAgent',
+    model='googleai/gemini-flash-latest',
+    system='Weather assistant. Use getWeather for weather questions.',
+    tools=[get_weather],
+    # store is optional. Omit it for client-managed state (see below).
+    store=InMemorySessionStore(),
+)
+```
+
+Common `define_agent` options:
+
+- `name` (required): action name.
+- `model`: model id (e.g. `googleai/gemini-flash-latest`).
+- `system`: system prompt (`str` or list of parts).
+- `tools`: tools available to the agent.
+- `use`: middleware instances (e.g. `ToolApproval`, `Artifacts`, `Filesystem`).
+- `store`: a `SessionStore` for server-side persistence. See [sessions](agents-sessions.md).
+- `state_schema`: a Pydantic model describing custom session state.
+- `max_turns`, `config`, `description`, `metadata`, `state_transform`, `chunk_transform`.
+
+For a registered Dotprompt, use `ai.define_prompt_agent(name=...)` with the same
+prompt name. For full turn control, use [`define_custom_agent`](agents-custom.md).
+
+## Agents and middleware go hand in hand
+
+Most agent capabilities — artifacts, filesystem access, skill loading, tool
+approval, retries — are middleware you pass via `use=[...]`. Register the
+middleware plugin once:
+
+```python
+from genkit_middleware import Middleware, ToolApproval, Filesystem, Skills, Retry
+from genkit.agent import FileSessionStore
+
+ai = Genkit(plugins=[GoogleAI(), Middleware()])
+
+coding_agent = ai.define_agent(
+    name='codingAgent',
+    model='googleai/gemini-flash-latest',
+    system='Expert coding assistant in a sandboxed workspace.',
+    use=[
+        # Empty allowed_tools ⇒ every tool needs approval; list names to auto-approve.
+        ToolApproval(allowed_tools=['list_files', 'read_file', 'use_skill']),
+        Filesystem(root_dir='./workspace', allow_write_access=True),
+        Skills(skill_paths=['./skills']),
+        Retry(),
+    ],
+    store=FileSessionStore('./.snapshots'),  # needed for durable approval/resume
+    max_turns=30,
+)
+```
+
+## Chat with an agent
+
+`agent.chat()` opens a conversation. One `chat` carries state forward across
+turns. There is **no `send_stream`** — streaming is on the turn object.
+
+```python
+chat = agent.chat()
+
+# Non-streaming: await the response directly.
+res = await chat.send('Weather in Tokyo?').response
+print(res.text)
+print(res.snapshot_id)  # immutable checkpoint id (None if no store)
+
+# Streaming: iterate turn.stream, then await turn.response.
+turn = chat.send('What about Paris?')
+async for chunk in turn.stream:
+    if chunk.text:
+        print(chunk.accumulated_text, end='\r', flush=True)
+final = await turn.response
+```
+
+Follow-up turns on the same `chat` remember prior context automatically.
+
+## Resume a stored conversation
+
+With a store, hold onto `snapshot_id` and rehydrate later:
+
+```python
+checkpoint = res.snapshot_id
+resumed = await agent.load_chat(snapshot_id=checkpoint)
+await resumed.send('What city did I ask about?').response
+```
+
+You can also open `agent.chat(snapshot_id=...)` when you already know the id.
+
+## Client-managed state (no server store)
+
+If the agent has **no `store`**, the server is stateless. `session_id` /
+`snapshot_id` stay `None`. You own messages + custom state + artifacts and
+hand them back on the next chat:
+
+```python
+agent = ai.define_agent(
+    name='echoNoStore',
+    model='googleai/gemini-flash-latest',
+    system='Echo assistant. Answer briefly and remember context.',
+)
+
+chat = agent.chat()
+await chat.send('My name is Ada. Remember it.').response
+
+messages, state, artifacts = chat.messages, chat.state, chat.artifacts
+resumed = agent.chat(messages=messages, state=state, artifacts=artifacts)
+await resumed.send('What is my name? One word.').response
+```
+
+Use client-managed state when you don't want server-side storage. Use a
+[session store](agents-sessions.md) when the server should own history, or when
+you need branching or background execution. ([Interrupts](agents-human-in-the-loop.md)
+work either way.)
+
+## Entrypoint
+
+For apps started with `genkit start`, use `ai.run_main(main())`:
+
+```python
+async def main() -> None:
+    chat = agent.chat()
+    print((await chat.send('hi').response).text)
+
+if __name__ == '__main__':
+    ai.run_main(main())
+```

--- a/skills/developing-genkit-python/references/agents.md
+++ b/skills/developing-genkit-python/references/agents.md
@@ -16,7 +16,7 @@ An **agent** is a persistent, multi-turn conversation primitive built on prompts
 - **Branching**: fork a conversation from any snapshot.
 - **Detaching**: run a turn in the background and poll for the result.
 
-Progressive disclosure — read the file for the level you need:
+Related topics:
 
 - This file: defining an agent, chatting, streaming, and **client-managed state** (no store).
 - [Sessions & persistence](agents-sessions.md): `SessionStore`, `InMemorySessionStore`, `FileSessionStore`, `FirestoreSessionStore`.
@@ -93,11 +93,10 @@ Common `define_agent` options:
 For a registered Dotprompt, use `ai.define_prompt_agent(name=...)` with the same
 prompt name. For full turn control, use [`define_custom_agent`](agents-custom.md).
 
-## Agents and middleware go hand in hand
+## Middleware
 
-Most agent capabilities — artifacts, filesystem access, skill loading, tool
-approval, retries — are middleware you pass via `use=[...]`. Register the
-middleware plugin once:
+Artifacts, filesystem access, skill loading, tool approval, and retries are
+middleware passed via `use=[...]`. Register the middleware plugin once:
 
 ```python
 from genkit_middleware import Middleware, ToolApproval, Filesystem, Skills, Retry
@@ -124,25 +123,22 @@ coding_agent = ai.define_agent(
 ## Chat with an agent
 
 `agent.chat()` opens a conversation. One `chat` carries state forward across
-turns. Prefer the **Action-style** split (same idea as `ai.generate` /
-`ai.generate_stream` and `Action.run` / `Action.stream`):
+turns:
 
 | Method | Returns | When to use |
 | --- | --- | --- |
-| `await chat.send(...)` | `AgentResponse` | Primary path — you only need the final result |
-| `chat.send_stream(...)` | `AgentTurn` (`.stream` / `.response`) | You want incremental chunks |
-| `await chat.resume(...)` | `AgentResponse` | Continue after an interrupt (non-streaming) |
-| `chat.resume_stream(...)` | `AgentTurn` | Continue after an interrupt (streaming) |
+| `await chat.send(...)` | `AgentResponse` | Final result only |
+| `chat.send_stream(...)` | `AgentTurn` (`.stream` / `.response`) | Incremental chunks |
+| `await chat.resume(...)` | `AgentResponse` | Continue after an interrupt |
+| `chat.resume_stream(...)` | `AgentTurn` | Continue after an interrupt, with chunks |
 
 ```python
 chat = agent.chat()
 
-# Non-streaming (primary) — prefer this when you don't need chunks:
 res = await chat.send('Weather in Tokyo?')
 print(res.text)
 print(res.snapshot_id)  # immutable checkpoint id (None if no store)
 
-# Streaming — same turn, with a live chunk view:
 turn = chat.send_stream('What about Paris?')
 async for chunk in turn.stream:
     if chunk.text:
@@ -151,16 +147,14 @@ final = await turn.response
 # or: final = await turn
 ```
 
-### Streaming semantics (important)
+Streaming notes:
 
-- **You do not have to drain chunks.** `await turn.response` (or `await turn`)
-  completes whether or not you read `.stream`. Custom-state patches and
-  message stitching still apply — the client pumps the transport internally.
-- **Chunks are per-turn.** Each `send_stream` / `resume_stream` has its own
-  buffer. Unread chunks from turn N do **not** show up on turn N+1's stream.
-  Dropping the turn handle (or draining it later) is how unread chunks go away.
-- **Don't overlap sends on one `chat`.** Turns are single-flight; overlapping
-  `send` / `send_stream` on the same session can corrupt local history.
+- `await turn.response` (or `await turn`) completes whether or not you read
+  `.stream`. Custom-state patches and message stitching still apply.
+- Each `send_stream` / `resume_stream` has its own chunk buffer. Unread chunks
+  from one turn do not appear on the next turn's stream.
+- Turns on a single `chat` are single-flight — do not overlap `send` /
+  `send_stream` calls on the same session.
 
 Follow-up turns on the same `chat` remember prior context automatically.
 

--- a/skills/developing-genkit-python/references/common-errors.md
+++ b/skills/developing-genkit-python/references/common-errors.md
@@ -46,9 +46,9 @@ async for chunk in turn.stream:
 res = await turn.response
 ```
 
-Do **not** assume `send` returns a stream handle, or that you must drain
-`send_stream` for the turn to finish / for `chat.state` patches to apply.
-`await turn.response` is enough; unread chunks stay on that turn only.
+`send` returns `AgentResponse`, not a stream handle. You do not need to drain
+`send_stream` for the turn to finish or for `chat.state` patches to apply —
+`await turn.response` is enough. Unread chunks stay on that turn only.
 
 ---
 

--- a/skills/developing-genkit-python/references/common-errors.md
+++ b/skills/developing-genkit-python/references/common-errors.md
@@ -35,7 +35,7 @@ assert hasattr(Genkit, 'define_agent')
 ## TypeError / wrong shape from `chat.send`
 
 **Cause:** `chat.send` is async and returns `AgentResponse`. Streaming lives on
-`chat.send_stream` (same split as `Action.run` / `Action.stream`).
+`chat.send_stream`.
 
 **Fix:**
 ```python

--- a/skills/developing-genkit-python/references/common-errors.md
+++ b/skills/developing-genkit-python/references/common-errors.md
@@ -32,13 +32,15 @@ assert hasattr(Genkit, 'define_agent')
 
 ---
 
-## AttributeError: 'AgentChat' object has no attribute 'send_stream'
+## TypeError / wrong shape from `chat.send`
 
-**Cause:** There is no `send_stream` on the Python agent chat client.
+**Cause:** `chat.send` is async and returns `AgentResponse`. Streaming lives on
+`chat.send_stream` (same split as `Action.run` / `Action.stream`).
 
-**Fix:** Use the turn's stream:
+**Fix:**
 ```python
-turn = chat.send('hi')
+res = await chat.send('hi')                 # non-streaming
+turn = chat.send_stream('hi')               # streaming
 async for chunk in turn.stream:
     ...
 res = await turn.response
@@ -85,7 +87,7 @@ restart_parts = [
     intr.restart(resumed_metadata={'tool_approved': True})
     for intr in out.interrupts
 ]
-await chat.resume(restart=restart_parts).response
+await chat.resume(restart=restart_parts)
 ```
 
 ---

--- a/skills/developing-genkit-python/references/common-errors.md
+++ b/skills/developing-genkit-python/references/common-errors.md
@@ -6,11 +6,86 @@
 
 ## ModuleNotFoundError: No module named 'genkit.plugins.google_genai'
 
-**Cause:** Plugin package not installed.
+**Cause:** Stale import path. The Google AI plugin is no longer under
+`genkit.plugins.google_genai`.
 
-**Fix:** Add dependencies from PyPI:
+**Fix:**
+```python
+from genkit_google_genai import GoogleAI  # correct
+```
 ```bash
 uv add genkit genkit-plugin-google-genai
+```
+
+---
+
+## AttributeError: 'Genkit' object has no attribute 'define_agent'
+
+**Cause:** Installed `genkit` build does not include agents yet (e.g. PyPI 0.8.x).
+
+**Fix:** Install from the agents branch / local checkout your team specifies
+until a release that exports `ai.define_agent` is published. Verify with:
+```python
+from genkit import Genkit
+assert hasattr(Genkit, 'define_agent')
+```
+
+---
+
+## AttributeError: 'AgentChat' object has no attribute 'send_stream'
+
+**Cause:** There is no `send_stream` on the Python agent chat client.
+
+**Fix:** Use the turn's stream:
+```python
+turn = chat.send('hi')
+async for chunk in turn.stream:
+    ...
+res = await turn.response
+```
+
+---
+
+## snapshot_id / session_id is None after a turn
+
+**Cause:** Agent was defined **without** a `store`. Ids are only minted when a
+session store is attached.
+
+**Fix:** Pass `store=InMemorySessionStore()` (or File/Firestore). Without a store,
+resume by round-tripping `chat.messages`, `chat.state`, and `chat.artifacts`.
+
+---
+
+## detach / chat.abort() fails or does nothing useful
+
+**Cause:** Background detach and **server-side** abort require a session store.
+
+**Also:** `turn.abort()` is a **client** detach (stop listening; server may
+still finish). `chat.abort()` / `task.abort()` cancel on the server.
+
+---
+
+## FAILED_PRECONDITION on session_id lookup after branching
+
+**Cause:** The session has multiple leaves; "latest" is ambiguous
+(`reject_ambiguous_session=True`).
+
+**Fix:** Resume with the specific leaf `snapshot_id`, not `session_id`.
+
+---
+
+## ToolApproval: tool still doesn't run after resume
+
+**Cause:** Resume parts missing approval metadata, or built by hand instead of
+from `res.interrupts`.
+
+**Fix:**
+```python
+restart_parts = [
+    intr.restart(resumed_metadata={'tool_approved': True})
+    for intr in out.interrupts
+]
+await chat.resume(restart=restart_parts).response
 ```
 
 ---
@@ -28,8 +103,6 @@ from pydantic import BaseModel
 async def get_weather(city: str) -> str: ...
 
 # Right
-from pydantic import BaseModel
-
 class WeatherInput(BaseModel):
     city: str
 

--- a/skills/developing-genkit-python/references/common-errors.md
+++ b/skills/developing-genkit-python/references/common-errors.md
@@ -39,12 +39,16 @@ assert hasattr(Genkit, 'define_agent')
 
 **Fix:**
 ```python
-res = await chat.send('hi')                 # non-streaming
+res = await chat.send('hi')                 # non-streaming (primary)
 turn = chat.send_stream('hi')               # streaming
 async for chunk in turn.stream:
     ...
 res = await turn.response
 ```
+
+Do **not** assume `send` returns a stream handle, or that you must drain
+`send_stream` for the turn to finish / for `chat.state` patches to apply.
+`await turn.response` is enough; unread chunks stay on that turn only.
 
 ---
 

--- a/skills/developing-genkit-python/references/dotprompt.md
+++ b/skills/developing-genkit-python/references/dotprompt.md
@@ -33,7 +33,7 @@ Place `.prompt` files in a `prompts/` directory and point `prompt_dir` at it.
 from pathlib import Path
 from pydantic import BaseModel
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/skills/developing-genkit-python/references/evals.md
+++ b/skills/developing-genkit-python/references/evals.md
@@ -26,7 +26,7 @@ Fields: `testCaseId`, `input`, `output`, `reference` (reference optional for som
 ## Built-in evaluators
 
 ```python
-from genkit.plugins.evaluators import register_genkit_evaluators
+from genkit_evaluators import register_genkit_evaluators
 register_genkit_evaluators(ai)
 ```
 

--- a/skills/developing-genkit-python/references/examples.md
+++ b/skills/developing-genkit-python/references/examples.md
@@ -4,7 +4,10 @@ Minimal patterns for common Genkit APIs. Examples use **Google AI** (`GoogleAI`,
 
 ## Public imports
 
-Use **`genkit`**, **`genkit.plugins.*`**, **`genkit.embedder`**, **`genkit.evaluator`**, and **`genkit.model`** (and similar public modules) only — not internal packages (`genkit._core`, etc.).
+Use public packages only — `genkit`, `genkit_google_genai`, `genkit_fastapi`,
+`genkit_middleware`, `genkit_evaluators`, `genkit.agent`, `genkit.embedder`,
+`genkit.evaluator`, `genkit.model`, etc. Do not import internal modules
+(`genkit._core`, …).
 
 ```python
 from genkit import Genkit, ActionRunContext
@@ -158,7 +161,7 @@ response = await ai.generate(prompt='Weather in Paris?', tools=[get_weather])
 ## Embeddings
 
 ```python
-from genkit.plugins.google_genai import GeminiEmbeddingModels
+from genkit_google_genai import GeminiEmbeddingModels
 
 embedder = f'googleai/{GeminiEmbeddingModels.GEMINI_EMBEDDING_001}'
 embeddings = await ai.embed(embedder=embedder, content='The sky is blue.')

--- a/skills/developing-genkit-python/references/examples.md
+++ b/skills/developing-genkit-python/references/examples.md
@@ -8,10 +8,12 @@ Use **`genkit`**, **`genkit.plugins.*`**, **`genkit.embedder`**, **`genkit.evalu
 
 ```python
 from genkit import Genkit, ActionRunContext
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 ```
+
+For agents, see [Agents](agents.md) (`from genkit.agent import ...`).
 
 ---
 

--- a/skills/developing-genkit-python/references/fastapi.md
+++ b/skills/developing-genkit-python/references/fastapi.md
@@ -49,8 +49,8 @@ from pydantic import BaseModel
 from fastapi import FastAPI
 from genkit import Genkit
 from genkit import ActionRunContext
-from genkit.plugins.fastapi import genkit_fastapi_handler
-from genkit.plugins.google_genai import GoogleAI
+from genkit_fastapi import genkit_fastapi_handler
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 app = FastAPI()

--- a/skills/developing-genkit-python/references/setup.md
+++ b/skills/developing-genkit-python/references/setup.md
@@ -7,11 +7,17 @@
 ```bash
 mkdir my-app && cd my-app
 uv init
-uv venv --python 3.14 .venv
+uv venv --python 3.12 .venv
 # Unix: source .venv/bin/activate
 # Windows: .venv\Scripts\activate
 uv add genkit genkit-plugin-google-genai
 export GEMINI_API_KEY=your_key_here
+```
+
+Import the Google AI plugin as:
+
+```python
+from genkit_google_genai import GoogleAI
 ```
 
 `uv init` creates `pyproject.toml`. Add your app under something like `src/main.py` (or match whatever layout `uv` generated) and point `genkit start` at that entrypoint.
@@ -24,17 +30,25 @@ Minimal `[project]` block with unpinned Genkit deps (resolver picks compatible r
 [project]
 name = "my-app"
 version = "0.1.0"
-requires-python = ">=3.14"
+requires-python = ">=3.10"
 dependencies = [
     "genkit",
     "genkit-plugin-google-genai",
 ]
 ```
 
+For **agents** + middleware (until published on the version you need), install from
+the agents branch / local Genkit Python checkout your team specifies, and add
+`genkit-plugin-middleware` (import: `genkit_middleware`) as needed.
+
 ## Plugins
 
-Packages are **`genkit-plugin-*`** on PyPI, e.g. `genkit-plugin-google-genai`, `genkit-plugin-vertex-ai`, `genkit-plugin-anthropic`, `genkit-plugin-fastapi`. Install with `uv add genkit-plugin-<name>`.
+Packages are **`genkit-plugin-*`** on PyPI, e.g. `genkit-plugin-google-genai`, `genkit-plugin-vertex-ai`, `genkit-plugin-anthropic`, `genkit-plugin-fastapi`, `genkit-plugin-middleware`. Install with `uv add genkit-plugin-<name>`.
+
+Import modules often differ from the PyPI name (e.g. `genkit_google_genai`,
+`genkit_middleware`). Prefer the imports in [Examples](examples.md) and
+[Agents](agents.md).
 
 ## Python version
 
-**3.14+**. Always use a `venv` using `uv venv --python 3.14 .venv` when creating the environment before you run any commands.
+**3.10+**. Prefer a project venv: `uv venv --python 3.12 .venv` (or newer) before you run commands.


### PR DESCRIPTION
## Summary
- Add Python agents references mirroring the JS skill structure (`agents.md` + sessions / HITL / branching / background / state / artifacts / custom / HTTP).
- Wire them from `developing-genkit-python/SKILL.md`, with a clear note that stable PyPI `genkit` 0.8.x does not yet export `define_agent`.
- Fix stale imports (`genkit_google_genai`, not `genkit.plugins.google_genai`), relax setup to Python 3.10+, and document common agent gotchas (no `send_stream`, store required for detach/abort ids, ToolApproval resume metadata).
- Document Python install in the repo README.

## Test plan
- [ ] Point Cursor/Claude at `skills/developing-genkit-python` and ask it to build a banking agent with `ToolApproval` + store resume
- [ ] Ask it to build a no-store multi-turn chat and resume via messages/state/artifacts
- [ ] Confirm it does **not** invent `send_stream` or `from genkit.plugins.google_genai import GoogleAI`
- [ ] Skim agent samples under `py/samples/agents/basic/` against the new reference snippets for drift