### PR TITLE
feat(developing-genkit-go): add experimental agents references

### DIFF
--- a/skills/developing-genkit-go/SKILL.md
+++ b/skills/developing-genkit-go/SKILL.md
@@ -83,7 +83,6 @@ For details see:
 
 ## Genkit CLI (recommended)
 
-
 `genkit start` unintrusively wraps any Go program that uses the Genkit library, running it unchanged while capturing traces from every Genkit action so you can prove tools were actually called and inspect model I/O from the terminal, even for headless checks. It forwards stdio, so interactive CLI tools that rely on stdin/stdout work without issues. Running the app directly (`go run .`) skips trace capture, so you're debugging blind. Check install with `genkit --version`.
 
 **Installation:**

--- a/skills/developing-genkit-go/SKILL.md
+++ b/skills/developing-genkit-go/SKILL.md
@@ -57,7 +57,32 @@ Load the appropriate reference based on what you need:
 | Flows & HTTP | [references/flows-and-http.md](references/flows-and-http.md) | `DefineFlow`, `DefineStreamingFlow`, `genkit.Handler`, HTTP serving |
 | Model Providers | [references/providers.md](references/providers.md) | Google AI, Vertex AI, Anthropic, OpenAI-compatible, Ollama setup |
 
+## Agents (Experimental)
+
+Genkit Go has an **experimental** agent API for persistent, multi-turn
+conversations (sessions, snapshots, interrupts, branching, background execution).
+It is gated: initialize with `genkit.Init(ctx, genkit.WithExperimental())` or the
+constructors panic. Server constructors come from `genkit/exp` (aliased
+`genkitx`); types and options from `ai/exp` (aliased `aix`); session stores from
+`ai/exp/localstore`.
+
+- **Agent or flow?** If the task is conversational, multi-turn, or described as "an agent", "assistant", or "chatbot", build it with `genkitx.DefineAgent` rather than hand-rolling a `Generate` + tools loop in a flow. Reach for a plain flow only for single-shot, stateless generation.
+
+For details see:
+
+-   [Agents](references/agents.md): defining/serving an agent, running turns, and client- vs server-managed state (start here).
+-   [Sessions & persistence](references/agents-sessions.md): session stores (`localstore.NewInMemorySessionStore`/`NewFileSessionStore`) and snapshots.
+-   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input and resuming.
+-   [Branching](references/agents-branching.md): forking a conversation from a snapshot.
+-   [Background agents](references/agents-background.md): detaching long-running turns and polling.
+-   [Working with state](references/agents-state.md): typed custom session state, streamed as JSON patches.
+-   [Artifacts](references/agents-artifacts.md): producing and reading named deliverables.
+-   [Multi-agent orchestration](references/agents-multi-agent.md): delegating to sub-agents.
+-   [Advanced custom agents](references/agents-custom.md): `DefineCustomAgent` for full turn control.
+-   [Deploying agents](references/agents-deployment.md): serving agents over HTTP with `genkit.Handler`.
+
 ## Genkit CLI (recommended)
+
 
 `genkit start` unintrusively wraps any Go program that uses the Genkit library, running it unchanged while capturing traces from every Genkit action so you can prove tools were actually called and inspect model I/O from the terminal, even for headless checks. It forwards stdio, so interactive CLI tools that rely on stdin/stdout work without issues. Running the app directly (`go run .`) skips trace capture, so you're debugging blind. Check install with `genkit --version`.
 

--- a/skills/developing-genkit-go/references/agents-artifacts.md
+++ b/skills/developing-genkit-go/references/agents-artifacts.md
@@ -1,0 +1,116 @@
+# Working with Artifacts (Experimental)
+
+> **Experimental / preview API.** The `Artifacts` middleware comes from
+> `plugins/middleware/exp`; the `Artifact` type from `ai/exp`. Read
+> [agents.md](agents.md) first.
+
+**Artifacts** are named, content-bearing deliverables an agent produces during a
+session — files, reports, code, etc. They live in the session (deduplicated by
+name) and are returned on `out.Artifacts`.
+
+```go
+import (
+	aix "github.com/genkit-ai/genkit/go/ai/exp"
+	middlewarex "github.com/genkit-ai/genkit/go/plugins/middleware/exp"
+)
+```
+
+## Give the model artifact tools
+
+The `middlewarex.Artifacts` middleware (see [using middleware](middleware.md))
+adds `read_artifact` and `write_artifact` tools and injects an `<artifacts>`
+listing (names + sizes, not full content) into the system prompt each turn. No
+custom tool code needed. Attach it via the `ai.WithUse` prompt option.
+
+```go
+workspaceAgent := genkitx.DefineAgent(g, "workspaceAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem(`You are a code generation assistant. Use write_artifact to create
+files (pass the filename as "name" and the full content as "content"). Use
+read_artifact to review or modify a previously created file.`),
+		ai.WithUse(&middlewarex.Artifacts{}),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+```
+
+Run it; artifacts are produced via the tool and returned in the output:
+
+```go
+out, _ := workspaceAgent.RunText(ctx, "Write poem.txt with a poem about Genkit")
+for _, a := range out.Artifacts {
+	fmt.Println(a.Name)
+}
+```
+
+`middlewarex.Artifacts` option:
+
+- `Readonly` (default `false`): when `true`, only `read_artifact` is provided —
+  the model can read but not create/update artifacts. Useful on an orchestrator
+  that should review (but not produce) sub-agent artifacts.
+
+```go
+ai.WithUse(&middlewarex.Artifacts{Readonly: true})
+```
+
+## The `Artifact` shape
+
+```go
+// An artifact's content lives in Parts (text/media parts). Metadata is optional.
+artifact := &aix.Artifact{
+	Name:     "poem.txt",
+	Parts:    []*ai.Part{ai.NewTextPart("Roses are red…")},
+	Metadata: map[string]any{"source": "workspaceAgent"}, // optional
+}
+```
+
+Writing the same `Name` again **replaces** the artifact (dedup by name).
+
+## Programmatic access (inside tools / custom agents)
+
+Use the session's artifact store. `aix.ArtifactStoreFromContext(ctx)` returns a
+`State`-agnostic view (so tools don't need to know the agent's `State` type), or
+`nil` when there is no active session.
+
+```go
+store := aix.ArtifactStoreFromContext(ctx)
+if store == nil {
+	// not inside an agent session
+}
+
+// Read all artifacts:
+for _, a := range store.Artifacts() {
+	if a.Name == "poem.txt" {
+		// ...
+	}
+}
+
+// Create / replace artifacts:
+store.AddArtifacts(&aix.Artifact{
+	Name:  "notes.md",
+	Parts: []*ai.Part{ai.NewTextPart("# Notes")},
+})
+```
+
+From a [custom agent](agents-custom.md) you can also stream an artifact to the
+client with `resp.SendArtifact(a)`, which forwards it and adds it to the session
+in one call.
+
+## Sharing artifacts across agents
+
+In [multi-agent orchestration](agents-multi-agent.md), set the `Agents`
+middleware's `ArtifactStrategy: middlewarex.ArtifactStrategySession` so sub-agent
+artifacts are merged into the parent session (namespaced by invocation ID), and
+add `&middlewarex.Artifacts{Readonly: true}` to the orchestrator so it can
+`read_artifact` them:
+
+```go
+ai.WithUse(
+	&middlewarex.Agents{
+		Agents:           []aix.AgentRef{{Name: "researcher"}, {Name: "coder"}},
+		ArtifactStrategy: middlewarex.ArtifactStrategySession,
+	},
+	&middlewarex.Artifacts{Readonly: true},
+)
+```

--- a/skills/developing-genkit-go/references/agents-artifacts.md
+++ b/skills/developing-genkit-go/references/agents-artifacts.md
@@ -23,7 +23,7 @@ listing (names + sizes, not full content) into the system prompt each turn. No
 custom tool code needed. Attach it via the `ai.WithUse` prompt option.
 
 ```go
-workspaceAgent := genkitx.DefineAgent(g, "workspaceAgent",
+workspaceAgent := genkitx.DefineAgent[any](g, "workspaceAgent",
 	aix.InlinePrompt{
 		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithSystem(`You are a code generation assistant. Use write_artifact to create
@@ -31,9 +31,14 @@ files (pass the filename as "name" and the full content as "content"). Use
 read_artifact to review or modify a previously created file.`),
 		ai.WithUse(&middlewarex.Artifacts{}),
 	},
-	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
 )
 ```
+
+No session store is needed to produce artifacts — they are returned on
+`out.Artifacts` either way (this agent is [client-managed](agents.md#client-managed-vs-server-managed-state),
+hence the explicit `[any]` type parameter). Add a store (e.g.
+`localstore.NewFileSessionStore`) only when artifacts should persist across turns
+or sessions. See [sessions](agents-sessions.md).
 
 Run it; artifacts are produced via the tool and returned in the output:
 

--- a/skills/developing-genkit-go/references/agents-background.md
+++ b/skills/developing-genkit-go/references/agents-background.md
@@ -1,0 +1,128 @@
+# Background Agents / Detaching (Experimental)
+
+> **Experimental / preview API.** Detaching **requires a
+> [session store](agents-sessions.md)** that also implements
+> `aix.SnapshotSubscriber` (both `localstore` stores do) — the server needs
+> somewhere to write the result and a way to observe an abort. Read
+> [agents.md](agents.md) first.
+
+Detaching runs a turn in the background: the server writes a `pending` snapshot
+and returns its `SnapshotID` **immediately**, keeps processing, then rewrites the
+snapshot to a terminal status (`completed` / `failed` / `aborted`). A reader polls
+`GetSnapshot` for completion and can `Abort` in the meantime.
+
+## Define the agent (store required)
+
+```go
+backgroundAgent := genkitx.DefineAgent(g, "backgroundAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a senior research analyst. Produce a comprehensive markdown report."),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()), // REQUIRED for detach
+)
+```
+
+## Detach a turn
+
+Set `Detach: true` on the input (or call `conn.Detach()` on a connection). The
+call returns right away with `FinishReason == aix.AgentFinishReasonDetached` and
+the pending snapshot's ID.
+
+```go
+out, err := backgroundAgent.Run(ctx, &aix.AgentInput{
+	Detach:  true,
+	Message: ai.NewUserTextMessage("Write a report on renewable energy trends"),
+})
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(out.FinishReason) // aix.AgentFinishReasonDetached
+snapshotID := out.SnapshotID  // pending; poll this
+```
+
+## Poll until terminal
+
+Read the snapshot on an interval until its status leaves `pending`.
+
+```go
+func waitForResult(ctx context.Context, agent *aix.Agent[any], snapshotID string) (*aix.SessionSnapshot[any], error) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		snap, err := agent.GetSnapshot(ctx, snapshotID)
+		if err != nil {
+			return nil, err
+		}
+		switch snap.Status {
+		case aix.SnapshotStatusPending:
+			// keep polling
+		case aix.SnapshotStatusCompleted:
+			return snap, nil
+		case aix.SnapshotStatusFailed:
+			return snap, fmt.Errorf("background task failed: %v", snap.Error)
+		case aix.SnapshotStatusAborted:
+			return snap, nil
+		case aix.SnapshotStatusExpired:
+			// The worker stopped sending heartbeats (e.g. the server restarted),
+			// so the task can never complete — treat as terminal.
+			return snap, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+snap, err := waitForResult(ctx, backgroundAgent, snapshotID)
+if err != nil {
+	log.Fatal(err)
+}
+// Read the result from the finalized snapshot state:
+msgs := snap.State.Messages
+if len(msgs) > 0 {
+	fmt.Println(msgs[len(msgs)-1].Text())
+}
+```
+
+## Abort an in-flight task
+
+`Agent.Abort` flips a pending snapshot to `aborted`; the runtime observes the
+flip and cancels the background work. It is a no-op on a missing or
+already-terminal snapshot (returns the existing status).
+
+```go
+status, err := backgroundAgent.Abort(ctx, snapshotID)
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(status) // aix.SnapshotStatusAborted (or the existing terminal status)
+```
+
+## Serve detach over HTTP
+
+A remote client drives the same story over HTTP: send `{"detach": true, ...}` as
+the turn input, poll the `getSnapshot` companion, and hit the `abort` companion.
+Expose both companions next to the agent:
+
+```go
+mux.HandleFunc("POST /api/backgroundAgent", genkit.Handler(backgroundAgent))
+mux.HandleFunc("POST /api/backgroundAgent/getSnapshot", genkit.Handler(backgroundAgent.GetSnapshotAction()))
+mux.HandleFunc("POST /api/backgroundAgent/abort", genkit.Handler(backgroundAgent.AbortAction()))
+```
+
+`AbortAction()` is non-nil only when the store implements `aix.SnapshotSubscriber`
+(both `localstore` stores do). See [deployment](agents-deployment.md).
+
+## Status values (`aix.SnapshotStatus`)
+
+- `SnapshotStatusPending` — still processing.
+- `SnapshotStatusCompleted` — finished successfully; read the result from
+  `snap.State.Messages`.
+- `SnapshotStatusFailed` — error during processing; details on `snap.Error`.
+- `SnapshotStatusAborted` — cancelled via `Abort`.
+- `SnapshotStatusExpired` — the background worker stopped responding (its
+  heartbeat went stale, e.g. a server restart). Computed on read, never
+  persisted; terminal — the task can never complete.

--- a/skills/developing-genkit-go/references/agents-branching.md
+++ b/skills/developing-genkit-go/references/agents-branching.md
@@ -1,0 +1,102 @@
+# Agent Branching (Experimental)
+
+> **Experimental / preview API.** Requires a [session store](agents-sessions.md)
+> so snapshots are persistent. Read [agents.md](agents.md) first.
+
+A `SnapshotID` is an **immutable checkpoint**, like a git commit. You can fork as
+many independent timelines as you want from the same snapshot — each turn from a
+snapshot creates a new, independent snapshot; the original is unchanged.
+
+To branch, run a turn resuming from an earlier snapshot via
+`aix.WithSnapshotID(id)`.
+
+## Branch from a checkpoint
+
+```go
+assistant := genkitx.DefineAgent(g, "assistant",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a helpful assistant."),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+
+root, _ := assistant.RunText(ctx, "Hello!")
+checkpoint := root.SnapshotID // branch point
+
+// Branch A — forks from `checkpoint`.
+a1, _ := assistant.RunText(ctx, "My name is Bob.", aix.WithSnapshotID(checkpoint))
+a2, _ := assistant.RunText(ctx, "What is my name?", aix.WithSnapshotID(a1.SnapshotID)) // -> Bob
+
+// Branch B — forks from the SAME `checkpoint`, fully independent.
+b1, _ := assistant.RunText(ctx, "My name is John.", aix.WithSnapshotID(checkpoint))
+b2, _ := assistant.RunText(ctx, "What is my name?", aix.WithSnapshotID(b1.SnapshotID)) // -> John
+
+_ = a2
+_ = b2
+```
+
+Each turn returns a fresh `SnapshotID`; the two branches never share one past the
+common `checkpoint`.
+
+## "Pick a variant"
+
+A common pattern: generate two variants from the same checkpoint in parallel,
+let the user pick one, and continue from the chosen snapshot.
+
+```go
+func twoVariants(ctx context.Context, agent *aix.Agent[any], checkpoint, text string) (a, b *aix.AgentOutput[any], err error) {
+	var wg sync.WaitGroup
+	var errA, errB error
+	wg.Add(2)
+	go func() { defer wg.Done(); a, errA = agent.RunText(ctx, text, aix.WithSnapshotID(checkpoint)) }()
+	go func() { defer wg.Done(); b, errB = agent.RunText(ctx, text, aix.WithSnapshotID(checkpoint)) }()
+	wg.Wait()
+	if errA != nil {
+		return nil, nil, errA
+	}
+	if errB != nil {
+		return nil, nil, errB
+	}
+	return a, b, nil // a.SnapshotID != b.SnapshotID; both branch from the same point
+}
+
+// When the user picks a variant, its SnapshotID becomes the new branch point:
+// checkpoint = chosen.SnapshotID
+```
+
+When no branch point exists yet (the very first turn), start a fresh session by
+omitting the invocation option, then use the returned `SnapshotID` as the branch
+point going forward.
+
+## Resume by session vs. by snapshot
+
+- `aix.WithSnapshotID(id)` — fork from an **exact** checkpoint (branching).
+- `aix.WithSessionID(id)` — continue the session's **latest** snapshot. If
+  history was forked, the most recently created branch wins; use
+  `WithSnapshotID` when you need a specific branch.
+
+## Restore history from a snapshot
+
+Use `Agent.GetSnapshot` to read a snapshot's state without starting a turn —
+handy for restoring a UI after a reload (e.g. a `SnapshotID` stored in the URL).
+
+```go
+snap, err := assistant.GetSnapshot(ctx, snapshotID)
+if err != nil {
+	log.Fatal(err)
+}
+for _, m := range snap.State.Messages {
+	if m.Role == ai.RoleUser || m.Role == ai.RoleModel {
+		fmt.Printf("%s: %s\n", m.Role, m.Text())
+	}
+}
+```
+
+Over HTTP, expose `Agent.GetSnapshotAction()` so a remote client can fetch
+snapshots (see [agents.md](agents.md#serve-an-agent-over-http)).
+
+> Abandoned branches simply remain in the store as immutable snapshots; nothing
+> is overwritten when you branch. (A `FileSessionStore` configured with
+> `WithMaxPersistedChainLength` prunes only along a single chain's parent links,
+> so sibling branches are retained independently.)

--- a/skills/developing-genkit-go/references/agents-custom.md
+++ b/skills/developing-genkit-go/references/agents-custom.md
@@ -1,0 +1,194 @@
+# Advanced Custom Agents — `DefineCustomAgent` (Experimental)
+
+> **Experimental / preview API.** `genkitx.DefineCustomAgent` comes from
+> `genkit/exp`. Read [agents.md](agents.md) and [agent state](agents-state.md)
+> first.
+
+`DefineAgent` runs a single prompt + tool loop. When you need **full control of
+the turn** — multiple sequential model calls, custom logic between them, manual
+message/state management, or custom progress streaming — use
+`genkitx.DefineCustomAgent`. You provide the function that runs the turn loop.
+
+## When to use it
+
+Reach for `DefineCustomAgent` when a turn needs to:
+
+- make **multiple model calls** with your own orchestration between them;
+- run **multi-step workflows** (decompose → research → synthesize);
+- **manually manage** messages and custom state;
+- **stream custom status** updates to the client mid-turn.
+
+Otherwise prefer `DefineAgent` (simpler; custom state still works — see
+[agent state](agents-state.md)).
+
+## Signature
+
+```go
+func DefineCustomAgent[State any](
+	g *genkit.Genkit,
+	name string,
+	fn aix.AgentFunc[State],
+	opts ...aix.AgentOption[State],
+) *aix.Agent[State]
+
+// where:
+type AgentFunc[State any] = func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[State]) (*aix.AgentResult, error)
+```
+
+Your `fn` receives:
+
+- `resp aix.Responder` — the output channel to the client. `resp.SendModelChunk(chunk)`
+  streams generation tokens; `resp.SendArtifact(a)` streams (and records) an
+  artifact. Sends are fire-and-forget.
+- `sess *aix.SessionRunner[State]` — the session plus turn-loop control. Call
+  `sess.Run(ctx, perTurn)` to enter the loop; it blocks per turn until the client
+  sends the next input.
+
+Key `sess` methods:
+
+- `sess.Run(ctx, func(ctx, input *aix.AgentInput) (*aix.TurnResult, error))` —
+  runs the turn loop. The incoming `input.Message` is added to the session before
+  your callback runs, so `sess.Messages()` includes it. Return a `*aix.TurnResult`
+  to report the finish reason (or `nil` to report none).
+- `sess.Messages()` / `sess.AddMessages(...)` / `sess.SetMessages(...)` — read and
+  write conversation history.
+- `sess.UpdateCustom(fn)` — mutate typed custom state; auto-streams a
+  `CustomPatch` chunk (see [state](agents-state.md)).
+- `sess.Result()` — build an `*aix.AgentResult` from the current session (last
+  message + artifacts), a convenience for the return value.
+
+## Example: multi-step research agent
+
+```go
+type ResearchState struct {
+	Status       string   `json:"status,omitempty"` // live progress shown to the client
+	SubQuestions []string `json:"subQuestions"`
+	SubAnswers   []QA     `json:"subAnswers"`
+}
+type QA struct {
+	Question string `json:"question"`
+	Answer   string `json:"answer"`
+}
+
+researchAgent := genkitx.DefineCustomAgent(g, "researchAgent",
+	func(ctx context.Context, resp aix.Responder, sess *aix.SessionRunner[ResearchState]) (*aix.AgentResult, error) {
+		var lastMessage *ai.Message
+		err := sess.Run(ctx, func(ctx context.Context, input *aix.AgentInput) (*aix.TurnResult, error) {
+			userText := input.Message.Text()
+
+			// Step 1: decompose. Mutating custom state auto-emits a CustomPatch
+			// chunk so the client's tracked state stays live.
+			sess.UpdateCustom(func(s ResearchState) ResearchState {
+				s.Status = "Decomposing question…"
+				return s
+			})
+			subQs, _, err := genkit.GenerateData[[]string](ctx, g,
+				ai.WithModelName("googleai/gemini-flash-latest"),
+				ai.WithPrompt("Break this into 2-3 sub-questions (JSON array): %q", userText),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			sess.UpdateCustom(func(s ResearchState) ResearchState {
+				s.SubQuestions, s.SubAnswers = *subQs, nil
+				return s
+			})
+
+			// Step 2: research each sub-question.
+			var answers []QA
+			for i, q := range *subQs {
+				sess.UpdateCustom(func(s ResearchState) ResearchState {
+					s.Status = fmt.Sprintf("Researching (%d/%d)", i+1, len(*subQs))
+					return s
+				})
+				a, err := genkit.GenerateText(ctx, g,
+					ai.WithModelName("googleai/gemini-flash-latest"),
+					ai.WithPrompt(q),
+				)
+				if err != nil {
+					return nil, err
+				}
+				answers = append(answers, QA{Question: q, Answer: a})
+			}
+			sess.UpdateCustom(func(s ResearchState) ResearchState {
+				s.SubAnswers, s.Status = answers, "Synthesizing…"
+				return s
+			})
+
+			// Step 3: synthesize and STREAM the final answer to the client.
+			var reason aix.AgentFinishReason
+			for result, err := range genkit.GenerateStream(ctx, g,
+				ai.WithModelName("googleai/gemini-flash-latest"),
+				ai.WithPrompt("Synthesize a unified answer from: %v", answers),
+			) {
+				if err != nil {
+					return nil, err
+				}
+				if result.Done {
+					lastMessage = result.Response.Message
+					reason = aix.AgentFinishReason(result.Response.FinishReason)
+					sess.AddMessages(lastMessage) // record the final response in history
+				} else {
+					resp.SendModelChunk(result.Chunk) // stream model output to the client
+				}
+			}
+			sess.UpdateCustom(func(s ResearchState) ResearchState { s.Status = "Done"; return s })
+
+			// Report how the turn ended; the framework forwards it on TurnEnd and
+			// persists it on the snapshot.
+			return &aix.TurnResult{FinishReason: reason}, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return sess.Result(), nil
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[ResearchState]()),
+)
+```
+
+## Custom status streaming
+
+Calling `sess.UpdateCustom(...)` during the turn automatically emits a
+`CustomPatch` chunk, so a connection's tracked [custom state](agents-state.md)
+(e.g. the `Status` field) stays live **mid-stream** without extra wiring. Stream
+model output separately with `resp.SendModelChunk(chunk)`.
+
+Run a custom agent exactly like a regular one:
+
+```go
+conn, _ := researchAgent.Connect(ctx,
+	aix.WithState(&aix.SessionState[ResearchState]{}),
+)
+_ = conn.SendText("Impacts of electric vehicles?")
+for chunk, err := range conn.Receive() {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if chunk.ModelChunk != nil {
+		fmt.Print(chunk.ModelChunk.Text()) // model output
+	}
+	if len(chunk.CustomPatch) > 0 {
+		cur, _ := conn.Custom()
+		fmt.Println("status:", cur.Status) // live progress
+	}
+	if chunk.TurnEnd != nil {
+		break
+	}
+}
+out, _ := conn.Output()
+```
+
+## Notes
+
+- **Per-turn metadata.** Inside the `sess.Run` callback,
+  `aix.TurnContextFromContext(ctx)` returns the turn's `SnapshotID`,
+  `ParentSnapshotID`, and `TurnIndex` — reserved before the turn runs, so you can
+  name external resources (e.g. a git worktree) after the snapshot up front.
+- **Validate untrusted resume.** If you accept `input.Resume` from untrusted
+  callers, call `aix.ValidateResumeAgainstHistory(input.Resume, sess.Messages())`
+  before forwarding it to the model (the prompt-backed loop does this for you).
+- **Recovering from a failed turn.** If your callback returns an error, `Run`
+  records the failure and stops; you may call `Run` again to keep processing, or
+  return the error to resolve the invocation as a failed `AgentOutput`.

--- a/skills/developing-genkit-go/references/agents-deployment.md
+++ b/skills/developing-genkit-go/references/agents-deployment.md
@@ -130,8 +130,13 @@ func withCORS(h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 	})
 }
+```
 
-log.Fatal(server.Start(ctx, "127.0.0.1:8080", withCORS(mux)))
+`server.Start` takes a `*http.ServeMux`, so wrap the mux with `http.ListenAndServe`
+(which accepts any `http.Handler`) to apply CORS around every route:
+
+```go
+log.Fatal(http.ListenAndServe("127.0.0.1:8080", withCORS(mux)))
 ```
 
 ## Registering agents

--- a/skills/developing-genkit-go/references/agents-deployment.md
+++ b/skills/developing-genkit-go/references/agents-deployment.md
@@ -1,0 +1,128 @@
+# Deploying / Serving Agents over HTTP (Experimental)
+
+> **Experimental / preview API.** Uses `genkit.Handler` and the agent's companion
+> actions. Read [agents.md](agents.md) first.
+
+An agent is an `api.BidiAction`, so `genkit.Handler(agent)` serves it as a
+standard HTTP action — **one turn per request**. Most agents also expose two
+companion actions:
+
+- `agent.GetSnapshotAction()` — read a snapshot's state. Needed for
+  [snapshot restore](agents-branching.md) and [background](agents-background.md)
+  polling. `nil` for a client-managed agent (no store).
+- `agent.AbortAction()` — cancel a [background](agents-background.md) turn.
+  `nil` unless the store implements `aix.SnapshotSubscriber` (both `localstore`
+  stores do).
+
+## Request/response shape
+
+The handler accepts `{"data": <AgentInput>, "init": <AgentInit>}`:
+
+- `data` — the turn's `aix.AgentInput` (message, resume, or `detach`). Required
+  for one-shot (non-streaming) requests.
+- `init` — the session source: `{"sessionId": ...}` or `{"snapshotId": ...}` for
+  server-managed agents, `{"state": ...}` for client-managed ones. Omit for a
+  fresh conversation.
+
+Responses come back as `{"result": <AgentOutput>}`. Set
+`Accept: text/event-stream` to stream chunks (`modelChunk`, `turnEnd`, then the
+final `result`). Turn-tier failures return **200** with a failed `AgentOutput`
+(so the caller keeps its last-good state); init-tier failures (a rejected session
+source) are hard HTTP errors (400/404).
+
+## A reusable helper for several agents
+
+`exp.ListAgents(g)` returns every registered agent, so you can mount them
+uniformly. A small helper keeps companion wiring consistent.
+
+```go
+func exposeAgent[State any](mux *http.ServeMux, agent *aix.Agent[State]) {
+	base := "/api/" + agent.Name()
+	mux.HandleFunc("POST "+base, genkit.Handler(agent))
+	if snap := agent.GetSnapshotAction(); snap != nil {
+		mux.HandleFunc("POST "+base+"/getSnapshot", genkit.Handler(snap))
+	}
+	if abort := agent.AbortAction(); abort != nil {
+		mux.HandleFunc("POST "+base+"/abort", genkit.Handler(abort))
+	}
+}
+
+mux := http.NewServeMux()
+exposeAgent(mux, weatherAgent)    // plain chat: no companions registered
+exposeAgent(mux, branchingAgent)  // has a store: getSnapshot registered
+exposeAgent(mux, backgroundAgent) // store + subscriber: getSnapshot + abort
+
+log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+```
+
+To mount every agent generically (companions are typed on the concrete
+`*aix.Agent[State]`, so from `exp.ListAgents` you serve the run action directly;
+pluck companions off the typed value where you have it):
+
+```go
+for _, a := range exp.ListAgents(g) {
+	mux.HandleFunc("POST /api/"+a.Name(), genkit.Handler(a))
+}
+```
+
+Which companions to enable:
+
+| Agent capability                          | `getSnapshot` | `abort` |
+| ----------------------------------------- | ------------- | ------- |
+| Plain chat (client- or server-state)      | –             | –       |
+| Snapshot restore / [branching](agents-branching.md) | ✓   | –       |
+| [Background](agents-background.md) / detach | ✓           | ✓       |
+
+## CORS for browser clients
+
+A browser calling a different origin (e.g. a Vite dev server) needs CORS.
+Streaming uses Server-Sent Events, so allow the `Accept` header and handle
+preflight.
+
+```go
+func withCORS(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+log.Fatal(server.Start(ctx, "127.0.0.1:8080", withCORS(mux)))
+```
+
+## Registering agents
+
+Agents register with Genkit when their `genkitx.DefineAgent` (or
+`DefineCustomAgent` / `DefinePromptAgent`) call runs, so make sure the code that
+defines them executes during startup. Keep a reference to the returned
+`*aix.Agent[State]` to reach `RunText`, `GetSnapshot`, `Abort`, and the companion
+actions from your own code.
+
+## Verifying locally
+
+Run under the Genkit CLI so turns are traced, and drive the endpoint with `curl`:
+
+```bash
+genkit start -- go run .
+```
+
+```bash
+# One-shot turn:
+curl -s localhost:8080/api/weatherAgent \
+  -H 'Content-Type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"Weather in Tokyo?"}]}}}'
+
+# Resume a server-managed session:
+curl -s localhost:8080/api/weatherAgent \
+  -H 'Content-Type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"And Paris?"}]}},"init":{"sessionId":"<id>"}}'
+```
+
+You can also exercise an agent from the CLI by wrapping one turn in a throwaway
+flow and using `genkit flow:run` (see [agents.md](agents.md#verify-an-agent-from-the-cli-flowrun)).

--- a/skills/developing-genkit-go/references/agents-deployment.md
+++ b/skills/developing-genkit-go/references/agents-deployment.md
@@ -24,16 +24,50 @@ The handler accepts `{"data": <AgentInput>, "init": <AgentInit>}`:
   server-managed agents, `{"state": ...}` for client-managed ones. Omit for a
   fresh conversation.
 
-Responses come back as `{"result": <AgentOutput>}`. Set
-`Accept: text/event-stream` to stream chunks (`modelChunk`, `turnEnd`, then the
-final `result`). Turn-tier failures return **200** with a failed `AgentOutput`
-(so the caller keeps its last-good state); init-tier failures (a rejected session
-source) are hard HTTP errors (400/404).
+Responses come back as `{"result": <AgentOutput>}`. Stream chunks (`modelChunk`,
+`turnEnd`, then the final `result`) by either setting `Accept: text/event-stream`
+or adding `?stream=true` to the URL — the handler honors both. Turn-tier failures
+return **200** with a failed `AgentOutput` (so the caller keeps its last-good
+state); init-tier failures (a rejected session source) are hard HTTP errors
+(400/404).
 
-## A reusable helper for several agents
+## Serve with the built-in route layout (recommended)
 
-`exp.ListAgents(g)` returns every registered agent, so you can mount them
-uniformly. A small helper keeps companion wiring consistent.
+`genkit/exp` ships a default HTTP layout so you don't hand-wire companions.
+`genkitx.AllAgentRoutes(g)` returns a `[]genkitx.Route` covering every registered
+agent; `genkitx.AgentRoutes(agent)` does one agent. Each `Route` exposes
+`Pattern()` (a `"METHOD /path"` string for `http.ServeMux`) and
+`Handler(opts...)` (builds the `genkit.Handler`, passing any `HandlerOption`s).
+The layout follows each agent's capabilities, mounting under `/agents`:
+
+```go
+mux := http.NewServeMux()
+for _, route := range genkitx.AllAgentRoutes(g) {
+	mux.HandleFunc(route.Pattern(), route.Handler())
+}
+log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+```
+
+This produces, per agent:
+
+```
+POST /agents/<name>                one turn per request
+POST /agents/<name>/getSnapshot    read a snapshot (store-backed agents)
+POST /agents/<name>/abort          abort background work (abortable stores)
+```
+
+Companion routes are omitted for capabilities an agent lacks: a client-managed
+agent contributes only its turn route. To serve specific agents instead of all
+of them, use `genkitx.AgentRoutes(agent)`; to expose flows,
+`genkitx.AllFlowRoutes(g)` / `genkitx.FlowRoutes(flow)`. Mix them by
+concatenating the route slices. Any router works the same way (Gin, Chi, Echo):
+read `Pattern()` and serve `Handler()`.
+
+## A reusable helper for several agents (manual wiring)
+
+If you'd rather wire routes by hand (a custom path scheme, extra middleware per
+route, a `/api`-style prefix), mount the agent and pluck its companions off the
+typed value. A small helper keeps companion wiring consistent.
 
 ```go
 func exposeAgent[State any](mux *http.ServeMux, agent *aix.Agent[State]) {
@@ -55,15 +89,19 @@ exposeAgent(mux, backgroundAgent) // store + subscriber: getSnapshot + abort
 log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
 ```
 
-To mount every agent generically (companions are typed on the concrete
-`*aix.Agent[State]`, so from `exp.ListAgents` you serve the run action directly;
-pluck companions off the typed value where you have it):
+To mount every agent generically, `genkitx.ListAgents(g)` returns every
+registered agent (companions are typed on the concrete `*aix.Agent[State]`, so
+from `ListAgents` you serve the run action directly and pluck companions off the
+typed value where you have it):
 
 ```go
-for _, a := range exp.ListAgents(g) {
+for _, a := range genkitx.ListAgents(g) {
 	mux.HandleFunc("POST /api/"+a.Name(), genkit.Handler(a))
 }
 ```
+
+For most deployments prefer the built-in route layout above
+(`genkitx.AllAgentRoutes`), which wires companions for you.
 
 Which companions to enable:
 

--- a/skills/developing-genkit-go/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-go/references/agents-human-in-the-loop.md
@@ -1,0 +1,209 @@
+# Agent Human-in-the-Loop / Interrupts (Experimental)
+
+> **Experimental / preview API.** Read [agents.md](agents.md) first.
+
+An **interrupt** pauses an agent mid-turn and hands control back to your code (or
+a human) — e.g. to approve a sensitive action, collect missing input, or confirm
+a plan. Internally it's a **tool call used as control flow**: the interrupting
+tool does not produce a normal result; it pauses the turn. You then **resume**
+from the exact point it paused.
+
+Interrupts are **orthogonal to persistence** — they work the same whether the
+agent uses a [session store](agents-sessions.md) or
+[client-managed state](agents.md#client-managed-vs-server-managed-state). The
+paused turn just needs to be carried back into the resume: with a store the
+session/snapshot ID does it; without one you round-trip the state blob.
+
+Flow: send a turn → the response finishes with
+`aix.AgentFinishReasonInterrupted` and carries interrupt parts → collect human
+input → send an `aix.ToolResume` payload to continue.
+
+## Define an interruptible tool
+
+`genkitx.DefineInterruptibleTool[In, Out, Resume]` defines a tool that can pause
+by calling `tool.Interrupt(data)`. The `Resume` type is what the caller sends
+back to continue; it arrives as the non-nil `res *Resume` parameter on
+re-execution.
+
+```go
+import (
+	"github.com/genkit-ai/genkit/go/ai"
+	"github.com/genkit-ai/genkit/go/ai/exp/tool"
+)
+
+type ApprovalAsk struct {
+	Action  string `json:"action"`
+	Details string `json:"details"`
+}
+type ApprovalReply struct {
+	Approved bool   `json:"approved"`
+	Feedback string `json:"feedback,omitempty"`
+}
+type TransferInput struct {
+	Amount    float64 `json:"amount"`
+	ToAccount string  `json:"toAccount"`
+}
+type TransferOutput struct {
+	Success       bool   `json:"success"`
+	TransactionID string `json:"transactionId"`
+}
+
+// transferMoney pauses for approval on the first call, then completes once a
+// resume payload (res) is supplied.
+transferMoney := genkitx.DefineInterruptibleTool(g, "transferMoney",
+	"Transfer money to a specified account, pausing for user approval.",
+	func(ctx context.Context, in TransferInput, res *ApprovalReply) (TransferOutput, error) {
+		if res == nil {
+			// First call: pause and surface the request to the caller.
+			return TransferOutput{}, tool.Interrupt(ApprovalAsk{
+				Action:  "transferMoney",
+				Details: fmt.Sprintf("Transfer $%.2f to %s", in.Amount, in.ToAccount),
+			})
+		}
+		if !res.Approved {
+			return TransferOutput{Success: false}, nil
+		}
+		return TransferOutput{Success: true, TransactionID: fmt.Sprintf("txn-%d", time.Now().Unix())}, nil
+	},
+)
+
+bankingAgent := genkitx.DefineAgent(g, "bankingAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a banking assistant. Use transferMoney to move funds; it will pause for user approval."),
+		ai.WithTools(transferMoney),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+```
+
+`tool.Interrupt(data)` requires `data` to serialize to a JSON object (a struct or
+map), since it rides as structured metadata on the interrupted tool request.
+
+## Detect and resume
+
+When a turn pauses, its output has `FinishReason == aix.AgentFinishReasonInterrupted`.
+The interrupt parts are on the last model message; read the typed payload with
+`tool.InterruptAs[T]`. Build the resume payload from the **same** interrupt part
+(so it validates against history) with `InterruptibleTool.Respond` (supply the
+output directly) or `InterruptibleTool.Resume` (re-run the tool with typed resume
+data), and continue with `aix.ToolResume`.
+
+```go
+conn, _ := bankingAgent.Connect(ctx)
+
+_ = conn.SendText("Transfer $500 to my savings account.")
+
+var interruptPart *ai.Part
+for chunk, err := range conn.Receive() {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if chunk.ModelChunk != nil {
+		for _, p := range chunk.ModelChunk.Content {
+			if p.IsToolRequest() {
+				interruptPart = p
+			}
+		}
+	}
+	if chunk.TurnEnd != nil {
+		break
+	}
+}
+
+if interruptPart != nil {
+	if ask, ok := tool.InterruptAs[ApprovalAsk](interruptPart); ok {
+		fmt.Println(ask.Action, ask.Details) // show this to the human
+	}
+
+	// Collect the human decision, then build a respond part for the SAME tool.
+	respond, err := transferMoney.Respond(interruptPart, TransferOutput{
+		Success:       true,
+		TransactionID: "txn-approved",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Resume the same connection with the tool response.
+	_ = conn.SendResume(&aix.ToolResume{Respond: []*ai.Part{respond}})
+	for chunk, err := range conn.Receive() {
+		if err != nil {
+			log.Fatal(err)
+		}
+		if chunk.ModelChunk != nil {
+			fmt.Print(chunk.ModelChunk.Text())
+		}
+		if chunk.TurnEnd != nil {
+			break
+		}
+	}
+}
+
+out, _ := conn.Output()
+```
+
+### Respond vs. Restart
+
+- `tool.Respond` / `InterruptibleTool.Respond(part, output)` — supply the tool's
+  output **without** re-running it. Goes on `aix.ToolResume{Respond: [...]}`.
+- `tool.Resume` / `InterruptibleTool.Resume(part, resumeData)` — **re-run** the
+  interrupted tool, delivering `resumeData` as its `res *Resume` parameter. Goes
+  on `aix.ToolResume{Restart: [...]}`.
+
+```go
+// Re-run the tool with the human's decision instead of injecting the result:
+restart, _ := transferMoney.Resume(interruptPart, ApprovalReply{Approved: true, Feedback: "ok"})
+_ = conn.SendResume(&aix.ToolResume{Restart: []*ai.Part{restart}})
+```
+
+You can resume several interrupts at once and mix the two lists:
+
+```go
+_ = conn.SendResume(&aix.ToolResume{
+	Respond: []*ai.Part{a},
+	Restart: []*ai.Part{b},
+})
+```
+
+## Single-turn resume with `Run`
+
+You don't need a persistent connection. Detect the interrupt on one `Run`, then
+resume with another `Run` carrying the `Resume` payload (plus the session source
+so the paused turn is in scope).
+
+```go
+out, _ := bankingAgent.RunText(ctx, "Transfer $500 to savings.")
+if out.FinishReason == aix.AgentFinishReasonInterrupted {
+	part := out.Message.Content[len(out.Message.Content)-1] // the interrupt part
+	respond, _ := transferMoney.Respond(part, TransferOutput{Success: true, TransactionID: "txn-1"})
+
+	out, _ = bankingAgent.Run(ctx,
+		&aix.AgentInput{Resume: &aix.ToolResume{Respond: []*ai.Part{respond}}},
+		aix.WithSessionID(out.SessionID), // server-managed: carry the paused turn back
+	)
+}
+fmt.Println(out.Message.Text())
+```
+
+For a client-managed agent, pass `aix.WithState(out.State)` instead of
+`WithSessionID`.
+
+## Notes & gotchas
+
+- **No store required.** Interrupts work with a [session store](agents-sessions.md)
+  or [client-managed state](agents.md#client-managed-vs-server-managed-state).
+  Just carry the paused turn back into the resume (session/snapshot ID, or the
+  state blob).
+- **Build resume parts from the interrupt part.** `Respond`/`Resume` derive the
+  name/ref from the original request. The framework validates every entry against
+  conversation history (`aix.ValidateResumeAgainstHistory` runs automatically for
+  prompt-backed agents): name/ref must match, and a `Restart` input must be
+  unchanged. Hand-rolled parts are rejected.
+- **Only resumable snapshots resume.** A failed/aborted/pending snapshot is kept
+  for inspection but can't be resumed.
+- **Re-pausing.** After resuming, the new turn may interrupt again; loop until
+  the finish reason is no longer `aix.AgentFinishReasonInterrupted`.
+- **`ToolApproval` middleware.** For gating arbitrary tools (rather than writing
+  an interruptible tool by hand), `plugins/middleware`'s `ToolApproval` turns any
+  tool call outside an allow list into an interrupt. See [middleware](middleware.md).

--- a/skills/developing-genkit-go/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-go/references/agents-human-in-the-loop.md
@@ -80,6 +80,18 @@ bankingAgent := genkitx.DefineAgent(g, "bankingAgent",
 `tool.Interrupt(data)` requires `data` to serialize to a JSON object (a struct or
 map), since it rides as structured metadata on the interrupted tool request.
 
+Returning an ordinary Go `error` from the tool is different: it **fails the turn**
+rather than pausing it. The runtime wraps the cause as `ai.ErrToolFailed` with the
+original preserved, so you can validate inputs and still branch on the classified
+status server-side, e.g.:
+
+```go
+if in.Amount <= 0 {
+	return TransferOutput{}, status.Errorf(status.ErrInvalidArgument,
+		"transfer amount must be positive, got $%.2f", in.Amount)
+}
+```
+
 ## Detect and resume
 
 When a turn pauses, its output has `FinishReason == aix.AgentFinishReasonInterrupted`.

--- a/skills/developing-genkit-go/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-go/references/agents-human-in-the-loop.md
@@ -29,6 +29,7 @@ re-execution.
 import (
 	"github.com/genkit-ai/genkit/go/ai"
 	"github.com/genkit-ai/genkit/go/ai/exp/tool"
+	"github.com/genkit-ai/genkit/go/core/status" // status.Errorf / status.ErrInvalidArgument
 )
 
 type ApprovalAsk struct {
@@ -187,7 +188,16 @@ so the paused turn is in scope).
 ```go
 out, _ := bankingAgent.RunText(ctx, "Transfer $500 to savings.")
 if out.FinishReason == aix.AgentFinishReasonInterrupted {
-	part := out.Message.Content[len(out.Message.Content)-1] // the interrupt part
+	// Find the interrupt part: don't assume it's the last content part. The
+	// model may emit text alongside the tool request, or several tool calls
+	// where only one interrupted. tool.InterruptAs matches the right one.
+	var part *ai.Part
+	for _, p := range out.Message.Content {
+		if _, ok := tool.InterruptAs[ApprovalAsk](p); ok {
+			part = p
+			break
+		}
+	}
 	respond, _ := transferMoney.Respond(part, TransferOutput{Success: true, TransactionID: "txn-1"})
 
 	out, _ = bankingAgent.Run(ctx,

--- a/skills/developing-genkit-go/references/agents-multi-agent.md
+++ b/skills/developing-genkit-go/references/agents-multi-agent.md
@@ -1,0 +1,135 @@
+# Multi-Agent Orchestration / Sub-Agents (Experimental)
+
+> **Experimental / preview API.** Sub-agent delegation uses the `Agents`
+> middleware from `plugins/middleware/exp`. Read [agents.md](agents.md) first.
+
+A common pattern is an **orchestrator** agent that delegates tasks to specialized
+**sub-agents** (e.g. a `researcher` and a `coder`). The `middlewarex.Agents`
+middleware injects one delegation tool per sub-agent (`delegate_to_<name>`),
+appends a `<sub-agents>` block to the orchestrator's system prompt, and — when the
+model calls a delegation tool — runs the sub-agent with the task and returns its
+response as the tool result.
+
+```go
+import (
+	aix "github.com/genkit-ai/genkit/go/ai/exp"
+	middlewarex "github.com/genkit-ai/genkit/go/plugins/middleware/exp"
+	"github.com/genkit-ai/genkit/go/plugins/middleware" // Retry, etc.
+)
+```
+
+## 1. Define the sub-agents
+
+Give each sub-agent a description via `aix.WithDescription` — it's
+auto-discovered and shown to the orchestrator so the model knows when to delegate.
+
+```go
+researcher := genkitx.DefineAgent(g, "researcher",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a thorough research assistant. Save findings with write_artifact."),
+		ai.WithUse(&middleware.Retry{}, &middlewarex.Artifacts{}),
+	},
+	aix.WithDescription[any]("A thorough research assistant that provides well-sourced answers."),
+)
+
+coder := genkitx.DefineAgent(g, "coder",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are an expert programmer. Save code with write_artifact."),
+		ai.WithUse(&middlewarex.Artifacts{}, &middleware.Retry{}),
+	},
+	aix.WithDescription[any]("An expert programmer that writes clean, well-commented code."),
+)
+```
+
+## 2. Wire up the orchestrator
+
+Add `&middlewarex.Agents{...}` to the orchestrator's `ai.WithUse`. Reference each
+sub-agent by `aix.AgentRef` — a bare `{Name: ...}` (description auto-discovered
+from the registry) or `agent.Ref()` (captures the agent's name and description).
+
+```go
+orchestrator := genkitx.DefineAgent(g, "orchestrator",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem(`You are a helpful project assistant. Analyze the request and
+delegate to the appropriate sub-agent. If it needs research AND code, call them
+sequentially, then synthesize a final answer.`),
+		ai.WithUse(
+			&middlewarex.Agents{
+				Agents: []aix.AgentRef{
+					{Name: "researcher"}, // by name (description auto-discovered)
+					coder.Ref(),          // by instance (carries its description)
+				},
+				MaxDelegations:   5,                                   // guard rail against runaway loops
+				HistoryLength:    4,                                   // forward the last N user/model messages as context
+				ArtifactStrategy: middlewarex.ArtifactStrategySession, // see "Sharing artifacts" below
+			},
+			&middlewarex.Artifacts{Readonly: true}, // read sub-agent artifacts via read_artifact
+			&middleware.Retry{},
+		),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+```
+
+Run it like any other agent:
+
+```go
+out, _ := orchestrator.RunText(ctx,
+	"Research the best sorting algorithms, then write a Go quicksort.")
+fmt.Println(out.Message.Text())
+```
+
+## `middlewarex.Agents` fields
+
+- `Agents` (required): sub-agent references (`[]aix.AgentRef`). Each is a bare
+  `{Name: ...}` (description auto-discovered) or `agent.Ref()` (explicit).
+- `ToolPrefix` (`*string`): prefix for generated delegation tool names. `nil`
+  defaults to `"delegate_to"` (tools become `delegate_to_<agent>`); a pointer to
+  the empty string uses bare agent names.
+- `MaxDelegations` (`int`): cap on delegations per generate call. `0` means
+  unlimited. Prevents runaway loops.
+- `HistoryLength` (`int`): number of recent user/model messages forwarded to a
+  sub-agent as context. `0` sends only the task description. History is forwarded
+  only to **client-managed** sub-agents (no session store); server-managed
+  sub-agents receive only the task.
+- `ArtifactStrategy` (`aix.ArtifactStrategy`): `ArtifactStrategyInline` (default)
+  or `ArtifactStrategySession` — see below.
+
+## Sharing artifacts between agents
+
+Sub-agents can produce [artifacts](agents-artifacts.md). `ArtifactStrategy`
+controls how they reach the orchestrator:
+
+- `middlewarex.ArtifactStrategyInline` (default): artifact content is included in
+  the delegation tool result (so the model sees it directly) **and** merged into
+  the parent session.
+- `middlewarex.ArtifactStrategySession`: artifacts are merged into the parent
+  session only; the tool result lists artifact names, not content. Pair it with
+  `&middlewarex.Artifacts{}` on the orchestrator so it can `read_artifact` on
+  demand (the pattern above). Merged artifacts are namespaced by an invocation ID
+  (`<agentName>_<n>/<name>`) and tagged with their source agent.
+
+## Combining with retries
+
+`plugins/middleware`'s `Retry` (and `Fallback`) attach the same way via
+`ai.WithUse` on an agent, and pair well with delegation:
+
+```go
+ai.WithUse(&middleware.Retry{
+	MaxRetries:     3,     // default 3
+	InitialDelayMs: 1000,  // default 1000
+	MaxDelayMs:     60000, // default 60000
+	BackoffFactor:  2,     // default 2
+})
+```
+
+See [using middleware](middleware.md) for the full catalog (`Retry`, `Fallback`,
+`ToolApproval`, `Filesystem`, `Skills`).
+
+> Note: if a sub-agent triggers an [interrupt](agents-human-in-the-loop.md), it is
+> reported back to the orchestrator as a normal tool response (not propagated as a
+> resumable interrupt). There is no stateful sub-agent runtime to resume into, so
+> delegate self-contained tasks.

--- a/skills/developing-genkit-go/references/agents-multi-agent.md
+++ b/skills/developing-genkit-go/references/agents-multi-agent.md
@@ -95,8 +95,9 @@ fmt.Println(out.Message.Text())
   sub-agent as context. `0` sends only the task description. History is forwarded
   only to **client-managed** sub-agents (no session store); server-managed
   sub-agents receive only the task.
-- `ArtifactStrategy` (`aix.ArtifactStrategy`): `ArtifactStrategyInline` (default)
-  or `ArtifactStrategySession` — see below.
+- `ArtifactStrategy` (`middlewarex.ArtifactStrategy`): `ArtifactStrategyInline`
+  (default) or `ArtifactStrategySession` — see below. The type and its constants
+  live in `plugins/middleware/exp` alongside the `Agents` middleware.
 
 ## Sharing artifacts between agents
 

--- a/skills/developing-genkit-go/references/agents-sessions.md
+++ b/skills/developing-genkit-go/references/agents-sessions.md
@@ -40,7 +40,7 @@ multi-instance production, implement `aix.SessionStore` against a real database
 - `localstore.WithSnapshotPathPrefix(fn)`: derive a per-call subdirectory from
   context to isolate snapshots per tenant (e.g. `"org-42/user-7"`).
 - `localstore.WithPollInterval(d)`: how often the store re-reads subscribed
-  snapshot files to observe cross-process status changes (default 1s). This is
+  snapshot files to observe cross-process status changes (default 2s). This is
   what lets one process abort a detached turn another process is running.
 
 ```go

--- a/skills/developing-genkit-go/references/agents-sessions.md
+++ b/skills/developing-genkit-go/references/agents-sessions.md
@@ -1,0 +1,188 @@
+# Agent Sessions & Persistence (Experimental)
+
+> **Experimental / preview API.** Session stores come from
+> `ai/exp/localstore`. Read [agents.md](agents.md) for the basics first.
+
+When an agent has a `SessionStore` (via `aix.WithSessionStore`), the **server**
+owns the session history. Each turn produces an immutable **snapshot**; the
+snapshot chain carries conversation state forward. A store also enables
+[branching](agents-branching.md) and [background execution](agents-background.md).
+(Interrupts work with or without a store — see
+[human-in-the-loop](agents-human-in-the-loop.md).)
+
+## Pick a store
+
+`ai/exp/localstore` ships two single-process stores. Both are generic over the
+custom-state type `State` (use `any` when you have no typed custom state).
+
+```go
+import "github.com/genkit-ai/genkit/go/ai/exp/localstore"
+
+// In-memory: great for tests/dev; lost on restart.
+memStore := localstore.NewInMemorySessionStore[any]()
+
+// File-backed: snapshots persisted as <dir>/<prefix>/<snapshotId>.json
+// (the prefix defaults to "global"). Returns an error if dir can't be created.
+fileStore, err := localstore.NewFileSessionStore[any]("./.snapshots")
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+`localstore` is for local development, tests, and single-instance apps. For
+multi-instance production, implement `aix.SessionStore` against a real database
+(see below).
+
+`NewFileSessionStore` options:
+
+- `localstore.WithMaxPersistedChainLength(n)`: keep only the newest `n`
+  snapshots in a chain (each save prunes older ancestors). `n >= 1`.
+- `localstore.WithSnapshotPathPrefix(fn)`: derive a per-call subdirectory from
+  context to isolate snapshots per tenant (e.g. `"org-42/user-7"`).
+- `localstore.WithPollInterval(d)`: how often the store re-reads subscribed
+  snapshot files to observe cross-process status changes (default 1s). This is
+  what lets one process abort a detached turn another process is running.
+
+```go
+pruning, err := localstore.NewFileSessionStore[any]("./.snapshots",
+	localstore.WithMaxPersistedChainLength(3),
+)
+```
+
+Attach a store to the agent with `aix.WithSessionStore`:
+
+```go
+logbookAgent := genkitx.DefineAgent(g, "logbookAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a personal logbook assistant."),
+	},
+	aix.WithSessionStore(fileStore),
+)
+```
+
+## Turns persist automatically
+
+Each turn writes a snapshot chained off the previous one. The turn's snapshot ID
+is on `out.SnapshotID`; the conversation's stable ID is on `out.SessionID`.
+
+```go
+out1, _ := logbookAgent.RunText(ctx, "Log this: I started studying Genkit today.")
+out2, _ := logbookAgent.RunText(ctx, "What did I study today?",
+	aix.WithSessionID(out1.SessionID)) // remembers turn 1
+fmt.Println(out1.SnapshotID, out2.SnapshotID)
+```
+
+## Resume a conversation
+
+Two ways to resume a server-managed conversation:
+
+- `aix.WithSessionID(id)` — resume the session's **latest** snapshot. Use it
+  when you track the conversation, not individual snapshots.
+- `aix.WithSnapshotID(id)` — resume a **specific** snapshot (see
+  [branching](agents-branching.md)).
+
+```go
+// Continue from the session's latest snapshot:
+out, _ := logbookAgent.RunText(ctx, "Add another note.",
+	aix.WithSessionID(sessionID))
+
+// Or continue from an exact checkpoint:
+out, _ = logbookAgent.RunText(ctx, "Add another note.",
+	aix.WithSnapshotID(snapshotID))
+```
+
+Resume is rejected if the latest snapshot is a failed, aborted, or pending dead
+end (a pending tip means a detached invocation is still running — wait for it or
+abort it). `aix.WithState` is for client-managed agents only and is mutually
+exclusive with `WithSessionID` / `WithSnapshotID`.
+
+## Read a snapshot without running a turn
+
+`Agent.GetSnapshot` / `Agent.GetLatestSnapshot` fetch a stored snapshot (applying
+any configured `aix.WithStateTransform`). Handy for restoring a UI after a
+reload. They return `FAILED_PRECONDITION` on a client-managed agent (no store).
+
+```go
+snap, err := logbookAgent.GetSnapshot(ctx, snapshotID)
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(snap.Status) // aix.SnapshotStatusCompleted, ...
+for _, m := range snap.State.Messages {
+	fmt.Println(m.Role, m.Text())
+}
+
+latest, _ := logbookAgent.GetLatestSnapshot(ctx, sessionID)
+```
+
+## Typed session state
+
+Parameterize the store (and agent) with a struct to attach typed **custom
+state**. State is validated (via JSON) when a snapshot is loaded. See
+[working with state](agents-state.md) for reading and mutating it inside tools.
+
+```go
+type Profile struct {
+	Name string `json:"name"`
+	Tier string `json:"tier"` // "free" | "pro"
+}
+
+profileAgent := genkitx.DefineAgent(g, "profileAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("Greet the user by name and tailor answers to their tier."),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[Profile]()),
+)
+
+// Seed custom state on the first turn (client-managed here for illustration;
+// with a store you would seed via WithState on a fresh session).
+out, _ := profileAgent.Run(ctx,
+	&aix.AgentInput{Message: ai.NewUserTextMessage("Hello")},
+	aix.WithState(&aix.SessionState[Profile]{
+		Custom: Profile{Name: "Ada", Tier: "pro"},
+	}),
+)
+```
+
+## Interrupts (human-in-the-loop)
+
+Interrupts pause a turn so a human can approve or provide input, then resume from
+the exact pause point. They work with a store or with client-managed state
+(persistence is orthogonal). See
+[Human-in-the-loop / interrupts](agents-human-in-the-loop.md).
+
+## Implementing a custom `SessionStore`
+
+For production, implement `aix.SessionStore` (which is `aix.SnapshotReader` +
+`aix.SnapshotWriter`) against your database. Add `aix.SnapshotSubscriber` to
+support [background/detach](agents-background.md) aborts.
+
+```go
+type SnapshotReader[State any] interface {
+	GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error)
+	GetLatestSnapshot(ctx context.Context, sessionID string) (*SessionSnapshot[State], error)
+}
+
+type SnapshotWriter[State any] interface {
+	// Atomically read the row at id (nil if absent), apply fn, and persist the
+	// result. fn must be pure (it may be retried). Returning (nil, nil) skips
+	// the write. The store owns identity (SnapshotID); the caller owns
+	// timestamps and Status. An empty id means "mint a fresh one".
+	SaveSnapshot(ctx context.Context, snapshotID string,
+		fn func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error),
+	) (*SessionSnapshot[State], error)
+}
+
+// Optional: enables detach/abort by observing status changes without polling.
+type SnapshotSubscriber interface {
+	OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus
+}
+```
+
+Contract notes: preserve `SessionID` across rewrites (a row's session never
+changes); default an empty `Status` to `SnapshotStatusCompleted`; keep
+`CreatedAt`/`UpdatedAt` caller-managed (persist them verbatim, never stamp them);
+`GetLatestSnapshot` returns the greatest-`CreatedAt` row, ties broken by
+`SnapshotID`. See the `localstore` implementations for a reference.

--- a/skills/developing-genkit-go/references/agents-state.md
+++ b/skills/developing-genkit-go/references/agents-state.md
@@ -1,0 +1,143 @@
+# Working with Agent State (Experimental)
+
+> **Experimental / preview API.** Read [agents.md](agents.md) first.
+
+Beyond message history, an agent session can hold typed **custom state** — your
+own structured data (a task list, a workflow status, counters, etc.). Tools read
+and mutate it during a turn, and every mutation is streamed to a connected client
+as a JSON Patch so the client's view stays live.
+
+## Declare the state shape
+
+The custom-state type is the `State` type parameter of the agent (and its store).
+It lives under `Custom` of `aix.SessionState[State]`.
+
+```go
+type TaskItem struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+	Done  bool   `json:"done"`
+}
+
+type TaskState struct {
+	Tasks  []TaskItem `json:"tasks"`
+	NextID int        `json:"nextId"`
+}
+
+taskAgent := genkitx.DefineAgent(g, "taskAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You manage the user's task list. Use the tools to modify it."),
+		ai.WithTools(addTask), // defined below
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[TaskState]()),
+)
+```
+
+## Read & mutate state inside tools
+
+Inside a tool, get the live session from context with
+`aix.SessionFromContext[State](ctx)`, then read with `session.Custom()` and
+mutate with `session.UpdateCustom(fn)`. `UpdateCustom` takes
+`func(State) State` and writes the result back atomically. When the session is
+driven by an agent invocation, the mutation is automatically streamed to the
+client as an `AgentStreamChunk.CustomPatch`.
+
+```go
+type AddTaskInput struct {
+	Title string `json:"title"`
+}
+
+addTask := genkit.DefineTool(g, "addTask",
+	"Add a new task. Returns the created task.",
+	func(ctx *ai.ToolContext, in AddTaskInput) (TaskItem, error) {
+		session := aix.SessionFromContext[TaskState](ctx.Context)
+		if session == nil {
+			return TaskItem{}, fmt.Errorf("addTask must run inside an agent session")
+		}
+		var created TaskItem
+		session.UpdateCustom(func(s TaskState) TaskState {
+			if s.NextID == 0 {
+				s.NextID = 1
+			}
+			created = TaskItem{ID: s.NextID, Title: in.Title, Done: false}
+			s.Tasks = append(s.Tasks, created)
+			s.NextID++
+			return s
+		})
+		return created, nil
+	},
+)
+```
+
+`aix.SessionFromContext[State]` returns `nil` outside an active session (or when
+the `State` type does not match), so guard against it. Note the tool's context is
+`ctx.Context` (the `*ai.ToolContext` embeds the standard `context.Context`).
+
+> Do not call other `Session` methods (or send on a `Responder`) from inside the
+> `UpdateCustom` callback: it runs while the session lock is held and would
+> deadlock.
+
+## Seed and read state
+
+Seed initial custom state with `aix.WithState` on the first turn. For a
+server-managed agent, later turns resume with `aix.WithSessionID` and the state
+is loaded from the snapshot.
+
+```go
+out, _ := taskAgent.Run(ctx,
+	&aix.AgentInput{Message: ai.NewUserTextMessage("Add a task: buy groceries")},
+	aix.WithState(&aix.SessionState[TaskState]{
+		Custom: TaskState{Tasks: nil, NextID: 1},
+	}),
+)
+// For a client-managed agent, the final state is on out.State:
+if out.State != nil {
+	fmt.Printf("%+v\n", out.State.Custom)
+}
+```
+
+## Live state on a connection
+
+A connection tracks custom state as it streams: each `Receive()`d chunk carries a
+`CustomPatch` (an RFC 6902 JSON Patch delta), which the connection applies to an
+internal copy. Read it any time with `conn.Custom()`.
+
+```go
+conn, _ := taskAgent.Connect(ctx,
+	aix.WithState(&aix.SessionState[TaskState]{Custom: TaskState{NextID: 1}}),
+)
+_ = conn.SendText("Add buy groceries, then mark it done")
+for chunk, err := range conn.Receive() {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(chunk.CustomPatch) > 0 {
+		cur, _ := conn.Custom() // TaskState reflecting deltas so far
+		fmt.Printf("live: %+v\n", cur)
+	}
+	if chunk.TurnEnd != nil {
+		break
+	}
+}
+```
+
+The first `CustomPatch` of each turn is a whole-document replace (re-basing the
+client); later patches are incremental diffs. The authoritative final state is on
+`out.State` (client-managed) or the turn-end snapshot (server-managed).
+
+## Prompt templating with state
+
+Inside a prompt template, the session's custom state is available as `{{@state}}`,
+evaluated fresh at render time so the template always sees the latest values.
+
+```go
+ai.WithSystem("The user's current task list: {{json @state.tasks}}. Help them manage it."),
+```
+
+## Custom status streaming from a custom agent
+
+For live mid-turn progress (a `status` field that updates as a long turn runs),
+mutate custom state from a [custom agent](agents-custom.md): every
+`UpdateCustom` emits a `CustomPatch` chunk automatically, so the connection's
+`Custom()` stays live without extra wiring.

--- a/skills/developing-genkit-go/references/agents.md
+++ b/skills/developing-genkit-go/references/agents.md
@@ -1,0 +1,303 @@
+# Agents (Experimental)
+
+> **Experimental / preview API.** Agents live in the `genkit/exp` and `ai/exp`
+> packages and are gated behind an opt-in. Initialize Genkit with
+> `genkit.WithExperimental()` or the constructors panic. Import paths and
+> signatures may change in any minor release.
+
+An **agent** is a persistent, multi-turn conversation primitive built on top of
+prompts + tools. Compared to a bare `genkit.Generate` loop, an agent adds:
+
+- **Sessions**: multi-turn history tracked as immutable **snapshots**.
+- **State**: typed session state (messages + custom data + artifacts).
+- **Interrupts**: human-in-the-loop pause/resume.
+- **Branching**: fork a conversation from any snapshot.
+- **Detaching**: run a turn in the background and poll for the result.
+
+Read the file for the level you need:
+
+- This file: defining an agent, running it, serving it, and **client-managed state** (no store).
+- [Sessions & persistence](agents-sessions.md): `SessionStore`, `localstore.NewInMemorySessionStore`, `localstore.NewFileSessionStore`.
+- [Human-in-the-loop / interrupts](agents-human-in-the-loop.md): pausing for approval/input and resuming.
+- [Branching](agents-branching.md): forking a conversation from a snapshot.
+- [Background agents](agents-background.md): detaching long-running turns and polling.
+- [Working with state](agents-state.md): typed custom session state and streamed patches.
+- [Artifacts](agents-artifacts.md): producing/reading named deliverables.
+- [Multi-agent orchestration](agents-multi-agent.md): delegating to sub-agents.
+- [Advanced custom agents](agents-custom.md): `DefineCustomAgent` for full turn control.
+- [Deploying agents](agents-deployment.md): serving agents over HTTP.
+
+## Packages and import aliases
+
+Agents span a few packages. These aliases are used throughout the agent docs:
+
+```go
+import (
+	"github.com/genkit-ai/genkit/go/ai"
+	aix "github.com/genkit-ai/genkit/go/ai/exp"           // types: Agent, Session, options, AgentInput/Output
+	"github.com/genkit-ai/genkit/go/ai/exp/localstore"    // session stores
+	"github.com/genkit-ai/genkit/go/genkit"
+	genkitx "github.com/genkit-ai/genkit/go/genkit/exp"   // constructors: DefineAgent, DefineCustomAgent, ...
+)
+```
+
+`genkitx` (genkit/exp) holds the registry-aware constructors you call.
+`aix` (ai/exp) holds the types, options, and the returned `*aix.Agent[State]`.
+Both packages are named `exp`, which is why the docs alias them `genkitx` and
+`aix`.
+
+## Setup
+
+```go
+ctx := context.Background()
+g := genkit.Init(ctx,
+	genkit.WithExperimental(), // REQUIRED: opts into the genkit/exp surface
+	genkit.WithPlugins(&googlegenai.GoogleAI{}),
+)
+```
+
+Without `genkit.WithExperimental()`, `genkitx.DefineAgent` (and every other
+`genkit/exp` constructor) panics with a message pointing you at the fix.
+
+## Define an agent
+
+`genkitx.DefineAgent` combines an inline prompt + tools + (optional) session
+store into a single registered action. The prompt is an `aix.InlinePrompt` — a
+slice of `ai.PromptOption` values, the same options you would pass to
+`genkit.DefinePrompt`.
+
+```go
+type WeatherInput struct {
+	City string `json:"city"`
+}
+type WeatherOutput struct {
+	TempC   float64 `json:"tempC"`
+	Summary string  `json:"summary"`
+}
+
+getWeather := genkit.DefineTool(g, "getWeather",
+	"Look up the current weather for a city.",
+	func(ctx *ai.ToolContext, in WeatherInput) (WeatherOutput, error) {
+		return WeatherOutput{TempC: 21, Summary: "Sunny"}, nil
+	},
+)
+
+weatherAgent := genkitx.DefineAgent(g, "weatherAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a helpful weather assistant. Use the getWeather tool. Be concise."),
+		ai.WithTools(getWeather),
+	},
+	// A session store is optional. Omit it for client-managed state (see below).
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+```
+
+The `State` type parameter is inferred from the typed options (here
+`aix.WithSessionStore(...[any]())` makes `State = any`). For a **client-managed**
+agent with no typed option, pass `State` explicitly:
+`genkitx.DefineAgent[any](g, "name", prompt)`.
+
+Constructor choices:
+
+- `genkitx.DefineAgent` — inline prompt (the common case, above).
+- `genkitx.DefinePromptAgent` — back the agent with a prompt already in the
+  registry (e.g. a `.prompt` file). By default it uses the prompt registered
+  under the agent's own name; use `aix.WithNamedPrompt` to point at another.
+- `genkitx.DefineCustomAgent` — full control over the turn loop. See
+  [advanced custom agents](agents-custom.md).
+
+Common agent options (all from `aix`):
+
+- `aix.WithSessionStore(store)`: server-side snapshot persistence. See [sessions](agents-sessions.md).
+- `aix.WithDescription[State](desc)`: human-readable description (shown in the Dev UI; used by [sub-agent delegation](agents-multi-agent.md)).
+- `aix.WithStateTransform[State](fn)`: rewrite state on its way out to a client (e.g. PII redaction).
+- `aix.WithStreamTransform[State](fn)`: rewrite stream chunks on their way out.
+
+## Agents and middleware go hand in hand
+
+Agents and [middleware](middleware.md) are built for each other: the
+`ai.WithUse(...)` prompt option layers in behavior without writing it yourself.
+Most agent capabilities — sub-agent delegation, artifacts, retries, fallback,
+tool approval — are just middleware you drop in.
+
+```go
+weatherAgent := genkitx.DefineAgent(g, "weatherAgent",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a helpful weather assistant."),
+		ai.WithTools(getWeather),
+		ai.WithUse(
+			&middleware.Retry{},        // plugins/middleware: retry transient model errors
+			&middlewarex.Artifacts{},   // plugins/middleware/exp: read_artifact / write_artifact
+		),
+	},
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+)
+```
+
+`plugins/middleware` provides `Retry`, `Fallback`, `ToolApproval`, `Filesystem`,
+and `Skills`. `plugins/middleware/exp` (aliased `middlewarex`) adds the
+agent-specific `Agents` (sub-agent delegation) and `Artifacts` middleware. See
+[using middleware](middleware.md) and [multi-agent](agents-multi-agent.md).
+
+## Run an agent (single turn)
+
+`Agent.RunText` and `Agent.Run` run one turn and return the final
+`*aix.AgentOutput[State]`.
+
+```go
+out, err := weatherAgent.RunText(ctx, "Weather in Tokyo?")
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(out.Message.Text())
+fmt.Println(out.SnapshotID)   // immutable checkpoint id for this turn (server-managed only)
+fmt.Println(out.FinishReason) // e.g. aix.AgentFinishReasonStop
+```
+
+`Run` takes an `*aix.AgentInput` when you need more than user text (a full
+message, a resume payload, or a detach signal):
+
+```go
+out, err := weatherAgent.Run(ctx, &aix.AgentInput{
+	Message: ai.NewUserTextMessage("Weather in Tokyo?"),
+})
+```
+
+In-band failures (a failed turn) resolve as a failed `AgentOutput`
+(`out.FinishReason == aix.AgentFinishReasonFailed`, `out.Error` populated), not a
+Go `error`. A returned `error` means the invocation never started (e.g. a
+rejected session source).
+
+## Chat with an agent (multi-turn)
+
+`Agent.Connect` opens a bidirectional streaming session. A single connection
+carries state forward automatically across turns. Send input, iterate
+`Receive()` until a `TurnEnd`, then send the next input.
+
+```go
+conn, err := weatherAgent.Connect(ctx)
+if err != nil {
+	log.Fatal(err)
+}
+
+// Turn 1 (streaming):
+_ = conn.SendText("Weather in Tokyo?")
+for chunk, err := range conn.Receive() {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if chunk.ModelChunk != nil {
+		fmt.Print(chunk.ModelChunk.Text())
+	}
+	if chunk.TurnEnd != nil {
+		break // turn done; safe to send the next input
+	}
+}
+
+// Turn 2 — history is carried automatically on the same connection:
+_ = conn.SendText("What about Paris?")
+for chunk, err := range conn.Receive() {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if chunk.TurnEnd != nil {
+		break
+	}
+}
+
+out, err := conn.Output() // finalize; closes input and drains remaining chunks
+```
+
+Connection helpers: `SendText`, `SendMessage`, `Send` (raw `*aix.AgentInput`),
+`SendResume` (see [interrupts](agents-human-in-the-loop.md)), `Detach` (see
+[background](agents-background.md)), `Receive` (chunk iterator), `Custom`
+(live custom state, see [state](agents-state.md)), `Output`, and `Close`.
+
+## Verify an agent from the CLI (`flow:run`)
+
+`genkit flow:run` runs **flows**, not agents, so you can't `flow:run` an agent
+directly. To exercise an agent from the CLI (a quick, self-terminating check),
+wrap one turn in a throwaway flow and run that:
+
+```go
+genkit.DefineFlow(g, "tryWeatherAgent", func(ctx context.Context, message string) (string, error) {
+	out, err := weatherAgent.RunText(ctx, message)
+	if err != nil {
+		return "", err
+	}
+	return out.Message.Text(), nil
+})
+// genkit flow:run tryWeatherAgent '"Weather in Tokyo?"' -- go run .
+```
+
+## Serve an agent over HTTP
+
+An agent is an `api.BidiAction`, so `genkit.Handler` serves it one turn per
+request. Optionally serve its companion actions for snapshot lookup
+(`GetSnapshotAction`) and background aborts (`AbortAction`); both are `nil` for a
+client-managed agent (no store).
+
+```go
+mux := http.NewServeMux()
+mux.HandleFunc("POST /api/weatherAgent", genkit.Handler(weatherAgent))
+
+// Optional companions (needed for snapshot restore / branching / background):
+if snap := weatherAgent.GetSnapshotAction(); snap != nil {
+	mux.HandleFunc("POST /api/weatherAgent/getSnapshot", genkit.Handler(snap))
+}
+if abort := weatherAgent.AbortAction(); abort != nil {
+	mux.HandleFunc("POST /api/weatherAgent/abort", genkit.Handler(abort))
+}
+
+log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+```
+
+The request body is `{"data": <AgentInput>, "init": <AgentInit>}`. `data` carries
+the turn's input; `init` carries the session source (see below). Set
+`Accept: text/event-stream` to stream chunks. For serving multiple agents, CORS
+headers for browser clients, and companion routing, see
+[Deploying agents](agents-deployment.md).
+
+## Client-managed vs server-managed state
+
+**Server-managed** (a `SessionStore` is configured): the server owns history as
+snapshots. Resume with `aix.WithSessionID` (latest snapshot of a session) or
+`aix.WithSnapshotID` (a specific snapshot). Over HTTP, `init` carries
+`{"sessionId": ...}` or `{"snapshotId": ...}`.
+
+```go
+out1, _ := weatherAgent.RunText(ctx, "Weather in London?")
+out2, _ := weatherAgent.RunText(ctx, "Is it sunny in Tokyo?",
+	aix.WithSessionID(out1.SessionID)) // resumes the conversation
+```
+
+**Client-managed** (no store): the server is stateless and the caller owns the
+session state blob (messages + custom + artifacts). Round-trip it via
+`aix.WithState` / `out.State`. Over HTTP, `init` carries `{"state": ...}`.
+
+```go
+statelessAgent := genkitx.DefineAgent[any](g, "weatherAgentStateless",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("You are a helpful weather assistant. Be concise."),
+		ai.WithTools(getWeather),
+	},
+)
+
+// First turn: start fresh; the framework mints a SessionID inside the state.
+out1, _ := statelessAgent.RunText(ctx, "Weather in London?")
+
+// Next turn: pass the returned state back to resume.
+out2, _ := statelessAgent.Run(ctx,
+	&aix.AgentInput{Message: ai.NewUserTextMessage("And Tokyo?")},
+	aix.WithState(out1.State),
+)
+fmt.Println(out2.State) // updated blob to carry forward again
+```
+
+Use client-managed state when you don't want server-side storage. Use a
+[session store](agents-sessions.md) when the server should own history, or when
+you need branching or background execution.
+([Interrupts](agents-human-in-the-loop.md) work either way.)

--- a/skills/developing-genkit-go/references/agents.md
+++ b/skills/developing-genkit-go/references/agents.md
@@ -107,6 +107,45 @@ Constructor choices:
 - `genkitx.DefineCustomAgent` — full control over the turn loop. See
   [advanced custom agents](agents-custom.md).
 
+### Backing an agent with a `.prompt` file
+
+`genkitx.DefinePromptAgent` pairs an agent with a prompt from the registry — for
+example a `.prompt` file loaded at startup — so prompt authors can tune the
+model, config, template, and default input without touching the Go wiring. With
+no source option it defaults to the prompt registered under the agent's own name.
+
+```prompt
+---
+# prompts/chef.prompt
+model: googleai/gemini-flash-latest
+input:
+  schema: ChatPromptInput
+  default:
+    personality: a Michelin-starred chef who loves explaining technique
+---
+You are {{personality}}. Keep every answer very brief, a few sentences at most.
+```
+
+If the `.prompt` frontmatter references a schema by name, register that Go type
+with `genkit.DefineSchemasFor` **before** defining the agent (the prompt is
+rendered at definition time):
+
+```go
+type ChatPromptInput struct {
+	Personality string `json:"personality"`
+}
+
+genkit.DefineSchemasFor(g, ChatPromptInput{}) // resolve "ChatPromptInput" in the .prompt
+
+chef := genkitx.DefinePromptAgent(g, "chef", // loads prompts/chef.prompt by name
+	aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
+	aix.WithDescription[any]("Michelin-starred chef"),
+)
+```
+
+To supply an input from code, or to back several agents with one shared prompt,
+add `aix.WithNamedPrompt(name, input)`.
+
 Common agent options (all from `aix`):
 
 - `aix.WithSessionStore(store)`: server-side snapshot persistence. See [sessions](agents-sessions.md).
@@ -256,9 +295,21 @@ log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
 
 The request body is `{"data": <AgentInput>, "init": <AgentInit>}`. `data` carries
 the turn's input; `init` carries the session source (see below). Set
-`Accept: text/event-stream` to stream chunks. For serving multiple agents, CORS
-headers for browser clients, and companion routing, see
-[Deploying agents](agents-deployment.md).
+`Accept: text/event-stream` (or add `?stream=true`) to stream chunks.
+
+Rather than wiring companions by hand, `genkit/exp` ships a default HTTP layout:
+`genkitx.AllAgentRoutes(g)` returns a route per registered agent (mounted under
+`/agents/<name>`, with `getSnapshot` / `abort` added for capable agents), which
+you range over onto a mux:
+
+```go
+for _, route := range genkitx.AllAgentRoutes(g) {
+	mux.HandleFunc(route.Pattern(), route.Handler())
+}
+```
+
+For serving multiple agents, the route helpers, CORS headers for browser clients,
+and companion routing, see [Deploying agents](agents-deployment.md).
 
 ## Client-managed vs server-managed state
 


### PR DESCRIPTION
Add a new "Agents (Experimental)" section to the Go skill covering the persistent multi-turn conversation API, including guidance on choosing between agents and flows, plus references for sessions, interrupts, branching, background execution, state, artifacts, orchestration, custom agents, and deployment.