### PR TITLE
docs: document --format json flag for trace commands

### DIFF
--- a/skills/developing-genkit-dart/SKILL.md
+++ b/skills/developing-genkit-dart/SKILL.md
@@ -78,11 +78,13 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 
 **Debugging with traces:** the fastest way to see prompts, model inputs/outputs, tool calls, latencies, and errors. Inspect from the terminal after any run under `genkit start`:
 ```bash
-genkit trace:list          # find recent trace IDs
-genkit trace:get <traceId> # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:list                        # find recent trace IDs
+genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq or other parsers
 ```
 
-Known issue: CLI trace output is human-oriented and may not be valid JSON (banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into JSON parsers. For complex traces, use grep or the Dev UI trace viewer.
+For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.
+
 
 **Documentation:**
 ```bash

--- a/skills/developing-genkit-go/SKILL.md
+++ b/skills/developing-genkit-go/SKILL.md
@@ -110,11 +110,13 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 
 **Debugging with traces:** the fastest way to see prompts, model inputs/outputs, tool calls, latencies, and errors. Inspect from the terminal after any run under `genkit start`:
 ```bash
-genkit trace:list          # find recent trace IDs
-genkit trace:get <traceId> # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:list                        # find recent trace IDs
+genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq or other parsers
 ```
 
-Known issue: CLI trace output is human-oriented and may not be valid JSON (banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into JSON parsers. For complex traces, use grep or the Dev UI trace viewer.
+For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.
+
 
 **Documentation:**
 ```bash

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -158,7 +158,7 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 ```bash
 genkit trace:list                        # find recent trace IDs
 genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
-genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq or other parsers
 ```
 
 For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.

--- a/skills/developing-genkit-js/SKILL.md
+++ b/skills/developing-genkit-js/SKILL.md
@@ -156,11 +156,13 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 
 **Debugging with traces:** the fastest way to see prompts, model inputs/outputs, tool calls, latencies, and errors. Inspect from the terminal after any run under `genkit start`:
 ```bash
-genkit trace:list          # find recent trace IDs
-genkit trace:get <traceId> # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:list                        # find recent trace IDs
+genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
 ```
 
-Known issue: CLI trace output is human-oriented and may not be valid JSON (banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into `jq`. For complex traces, use grep or the Dev UI trace viewer.
+For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.
+
 
 See [CLI Reference](references/docs-and-cli.md) for more commands, and `genkit --help` for the full list.
 

--- a/skills/developing-genkit-js/references/docs-and-cli.md
+++ b/skills/developing-genkit-js/references/docs-and-cli.md
@@ -77,6 +77,8 @@ For non-interactive/agent/CI use, add the global `--non-interactive` flag before
 
 -   **Get a trace**: `genkit trace:get <traceId>`
     -   Retrieves detailed information for a specific trace by its ID. This is particularly useful for debugging failed model calls, inspecting tool execution, or analyzing the exact inputs and outputs of a specific step in your flow.
+    -   **Machine-readable output**: add `--format json` (e.g. `genkit trace:get <traceId> --format json`) to get clean JSON you can pipe into `jq` or other parsers.
 -   **List traces**: `genkit trace:list [options]`
     -   Lists recent traces. Use this to find trace IDs from recent executions.
--   **Known issue**: CLI trace output is human-oriented and may not be valid JSON (extra banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into `jq` or other JSON parsers. For complex traces, use the Dev UI trace viewer (`genkit start`).
+-   **Piping to parsers**: the **default** trace output is human-oriented (extra banner/log lines, possible truncation on large traces), so don't pipe that form directly into `jq`. Use `--format json` for clean JSON, or the Dev UI trace viewer (`genkit start`) for complex traces.
+

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -99,11 +99,13 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 
 **Debugging with traces:** the fastest way to see prompts, model inputs/outputs, tool calls, latencies, and errors. Inspect from the terminal after any run under `genkit start`:
 ```bash
-genkit trace:list          # find recent trace IDs
-genkit trace:get <traceId> # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:list                        # find recent trace IDs
+genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
 ```
 
-Known issue: CLI trace output is human-oriented and may not be valid JSON (banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into `jq`. For complex traces, use grep or the Dev UI trace viewer.
+For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.
+
 
 See [Dev Workflow](references/dev-workflow.md) for the full checklist and Dev UI walkthrough.
 

--- a/skills/developing-genkit-python/SKILL.md
+++ b/skills/developing-genkit-python/SKILL.md
@@ -101,7 +101,7 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 ```bash
 genkit trace:list                        # find recent trace IDs
 genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
-genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq or other parsers
 ```
 
 For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.

--- a/skills/developing-genkit-python/references/dev-workflow.md
+++ b/skills/developing-genkit-python/references/dev-workflow.md
@@ -102,7 +102,7 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 ```bash
 genkit trace:list                        # find recent trace IDs
 genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
-genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq or other parsers
 ```
 
 For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.

--- a/skills/developing-genkit-python/references/dev-workflow.md
+++ b/skills/developing-genkit-python/references/dev-workflow.md
@@ -100,11 +100,13 @@ This is **self-terminating**: it runs the flow once, prints a `Trace ID`, then e
 
 **Debugging with traces:** the fastest way to see prompts, model inputs/outputs, tool calls, latencies, and errors. Inspect from the terminal after any run under `genkit start`:
 ```bash
-genkit trace:list          # find recent trace IDs
-genkit trace:get <traceId> # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:list                        # find recent trace IDs
+genkit trace:get <traceId>               # full trace details (inputs, outputs, tool calls, errors)
+genkit trace:get <traceId> --format json # machine-readable JSON, safe to pipe into jq
 ```
 
-Known issue: CLI trace output is human-oriented and may not be valid JSON (banner/log lines, possible truncation on large traces), so don't assume it pipes cleanly into `jq`. For complex traces, use grep or the Dev UI trace viewer.
+For machine-readable output, pass `--format json` to get clean JSON you can pipe into `jq` or other parsers. The **default** output is human-oriented (banner/log lines, possible truncation on large traces), so don't pipe that form directly; use `--format json`, grep, or the Dev UI trace viewer.
+
 
 **Documentation:**
 ```bash


### PR DESCRIPTION
Update trace debugging guidance across Dart, Go, and JS skills to recommend the `--format json` flag for machine-readable output that can be safely piped into jq or other parsers. Replaces the previous "known issue" note about human-oriented output not being valid JSON.