### PR TITLE
docs: update interrupt/tool API to return-based syntax

### DIFF
--- a/skills/developing-genkit-dart/SKILL.md
+++ b/skills/developing-genkit-dart/SKILL.md
@@ -31,8 +31,8 @@ artifacts, and multi-agent delegation). Server APIs come from
 `package:genkit/client.dart`. The `remoteAgent` client works from any Dart app,
 including **Flutter**, and the backend is fully interchangeable — it can talk to
 a Genkit agent implemented in Dart, JS/TypeScript, or Go over the same HTTP
-protocol. A few Dart specifics: interrupts are modeled as tools that call
-`ctx.interrupt(...)` (there is no `defineInterrupt`), sub-agent delegation uses
+protocol. A few Dart specifics: interrupts are modeled as tools that return
+`.interrupt(...)` (there is no `defineInterrupt`), sub-agent delegation uses
 the `agents()` middleware from `package:genkit_middleware`, and there is no
 `artifacts()` middleware yet (define artifact tools directly).
 
@@ -40,7 +40,7 @@ For more details see:
 
 -   [Agents](references/agents.md): defining/serving an agent and client-managed state (start here).
 -   [Sessions & persistence](references/agents-sessions.md): session stores (`InMemorySessionStore`/`FileSessionStore`/`FirestoreSessionStore`).
--   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input via `ctx.interrupt` and resuming.
+-   [Human-in-the-loop / interrupts](references/agents-human-in-the-loop.md): pausing for approval/input via `.interrupt(...)` and resuming.
 -   [Branching](references/agents-branching.md): forking a conversation from a snapshot.
 -   [Background agents](references/agents-background.md): detaching long-running turns and polling.
 -   [Working with state](references/agents-state.md): typed custom session state, auto-synced to the client.

--- a/skills/developing-genkit-dart/references/agents-artifacts.md
+++ b/skills/developing-genkit-dart/references/agents-artifacts.md
@@ -59,7 +59,7 @@ final writeArtifact = ai.defineTool(
     session.addArtifacts([
       Artifact(name: input.name, parts: [TextPart(text: input.content)]),
     ]);
-    return 'Wrote artifact "${input.name}".';
+    return .response('Wrote artifact "${input.name}".');
   },
 );
 
@@ -71,8 +71,8 @@ final readArtifact = ai.defineTool(
   fn: (input, _) async {
     final session = ai.currentSession()!;
     final match = session.getArtifacts().where((a) => a.name == input.name);
-    if (match.isEmpty) return 'Artifact "${input.name}" not found.';
-    return match.first.parts.map((p) => p.text ?? '').join();
+    if (match.isEmpty) return .response('Artifact "${input.name}" not found.');
+    return .response(match.first.parts.map((p) => p.text ?? '').join());
   },
 );
 

--- a/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
+++ b/skills/developing-genkit-dart/references/agents-human-in-the-loop.md
@@ -9,8 +9,9 @@ never runs to completion on the server; it pauses the turn. You then **resume**
 from the exact point it paused.
 
 > **Dart has no `defineInterrupt`.** Model an interrupt as a normal tool whose
-> body calls `ctx.interrupt(...)`. Because the tool never returns a value, omit
-> `outputSchema` — the output is supplied by the caller on resume.
+> body returns `.interrupt(data)`. Omit `outputSchema`; the output is supplied by
+> the caller on resume. (`ctx.interrupt(...)` still works but is soft-deprecated;
+> prefer `return .interrupt(...)`.)
 
 Interrupts are **orthogonal to persistence** — they work the same whether the
 agent uses a [session store](agents-sessions.md) or
@@ -23,7 +24,7 @@ Flow: `chat.send(text: ...)` → response has `res.interrupts` → collect human
 
 ## Define an interrupt (a tool that interrupts)
 
-Define it like a tool and add it to the agent's `tools`. `ctx.interrupt(...)`
+Define it like a tool and add it to the agent's `tools`. Returning `.interrupt(...)`
 pauses the turn; its argument is the data shown to the human.
 
 ```dart
@@ -60,7 +61,7 @@ final userApproval = ai.defineTool(
   name: 'userApproval',
   description: 'Ask the user for approval before a sensitive action.',
   inputSchema: UserApprovalInput.$schema,
-  fn: (input, ctx) async => ctx.interrupt(),
+  fn: (input, ctx) async => .interrupt(),
 );
 
 /// Executes the transfer. Only reached after the user approves.
@@ -69,10 +70,10 @@ final transferMoney = ai.defineTool(
   description: 'Transfer money to a specified account.',
   inputSchema: TransferMoneyInput.$schema,
   outputSchema: TransferMoneyOutput.$schema,
-  fn: (input, _) async => TransferMoneyOutput(
+  fn: (input, _) async => .response(TransferMoneyOutput(
     success: true,
     transactionId: 'txn-${DateTime.now().millisecondsSinceEpoch}',
-  ),
+  )),
 );
 
 final bankingAgent = ai.defineAgent(
@@ -193,7 +194,7 @@ await chat.resume(
 );
 ```
 
-If instead you write your own `ctx.interrupt(...)` gate inside a tool (as in the
+If instead you write your own `.interrupt(...)` gate inside a tool (as in the
 `coding_agent` sample), you inspect the resume payload yourself via the
 `ctx.resumed` getter:
 

--- a/skills/developing-genkit-dart/references/agents-state.md
+++ b/skills/developing-genkit-dart/references/agents-state.md
@@ -82,7 +82,7 @@ final addTask = ai.defineTool(
       state.nextId += 1;
       return state;
     });
-    return newTask;
+    return .response(newTask);
   },
 );
 ```
@@ -141,10 +141,10 @@ final toggleTask = ai.defineTool(
   name: 'toggleTask',
   description: 'Toggle a task done/undone by its ID.',
   inputSchema: ToggleTaskInput.$schema,
-  fn: (input, _) async => _mutateTaskById(input.id, (tasks, idx) {
+  fn: (input, _) async => .response(_mutateTaskById(input.id, (tasks, idx) {
     tasks[idx].done = !tasks[idx].done;
     return {'success': true, 'task': tasks[idx].toJson()};
-  }),
+  })),
 );
 ```
 

--- a/skills/developing-genkit-dart/references/agents.md
+++ b/skills/developing-genkit-dart/references/agents.md
@@ -82,10 +82,10 @@ final getWeather = ai.defineTool(
   description: 'Get the current weather for a given location.',
   inputSchema: GetWeatherInput.$schema,
   outputSchema: GetWeatherOutput.$schema,
-  fn: (input, _) async => GetWeatherOutput(
+  fn: (input, _) async => .response(GetWeatherOutput(
     weather: 'Sunny in ${input.location}',
     temperature: '71F',
-  ),
+  )),
 );
 
 final weatherAgent = ai.defineAgent(

--- a/skills/developing-genkit-dart/references/genkit.md
+++ b/skills/developing-genkit-dart/references/genkit.md
@@ -67,7 +67,7 @@ final weatherTool = ai.defineTool(
   inputSchema: WeatherInput.$schema,
   fn: (input, _) async {
     // Call your weather API here
-    return 'Weather in ${input.location}: 72°F and sunny';
+    return .response('Weather in ${input.location}: 72°F and sunny');
   },
 );
 
@@ -77,6 +77,25 @@ final response = await ai.generate(
   toolNames: ['getWeather'], // Use the tools
 );
 ```
+
+> **Tool functions return a `ToolResult`.** A tool's `fn` returns a
+> `ToolResult<Output>`, built with dot-shorthand:
+>
+> - `return .response(output)` for a normal result.
+> - `return .response(output, parts: [...])` to attach media parts alongside the
+>   structured output (multipart), e.g. an image the tool produced.
+> - `return .interrupt(data)` to pause the generation loop (see
+>   [human-in-the-loop](agents-human-in-the-loop.md)).
+>
+> ```dart
+> fn: (input, _) async => .response(
+>   {'result': 'captured'},
+>   parts: [MediaPart(media: Media(contentType: 'image/png', url: dataUri))],
+> );
+> ```
+>
+> Reading a tool's direct result (e.g. via `tool.call`) also yields a
+> `ToolResult`; read `(result as ToolResponseResult).output`.
 
 ## Structured Output
 

--- a/skills/developing-genkit-dart/references/genkit_google_genai.md
+++ b/skills/developing-genkit-dart/references/genkit_google_genai.md
@@ -35,7 +35,7 @@ final embeddings = await ai.embedMany(
 
 ## Image Generation
 
-The plugin also supports image generation models such as `gemini-2.5-flash-image`.
+The plugin also supports image generation models such as `gemini-3.1-flash-image`.
 
 ### Example (Nano Banana)
 
@@ -47,7 +47,7 @@ ai.defineFlow(
   outputSchema: Media.$schema,
   fn: (input, context) async {
     final response = await ai.generate(
-      model: googleAI.gemini('gemini-2.5-flash-image'),
+      model: googleAI.gemini('gemini-3.1-flash-image'),
       prompt: input,
     );
     if (response.media == null) {
@@ -72,7 +72,7 @@ ai.defineFlow(
   outputSchema: Media.$schema,
   fn: (prompt, _) async {
     final response = await ai.generate(
-      model: googleAI.gemini('gemini-2.5-flash-preview-tts'),
+      model: googleAI.gemini('gemini-3.1-flash-tts-preview'),
       prompt: prompt,
       config: GeminiTtsOptions(
         responseModalities: ['AUDIO'],

--- a/skills/developing-genkit-dart/references/genkit_mcp.md
+++ b/skills/developing-genkit-dart/references/genkit_mcp.md
@@ -88,7 +88,7 @@ void main() async {
     name: 'add',
     description: 'Add two numbers together',
     inputSchema: .map(.string(), .dynamicSChema()),
-    fn: (input, _) async => (input['a'] + input['b']).toString(),
+    fn: (input, _) async => .response((input['a'] + input['b']).toString()),
   );
 
   ai.defineResource(


### PR DESCRIPTION
Replace `ctx.interrupt(...)` with `return .interrupt(...)` and tool returns with `.response(...)` across Dart agent references. The old `ctx.interrupt(...)` is now soft-deprecated in favor of the return-based form.